### PR TITLE
refactor: Use width multiplier on YOLO modules from outside

### DIFF
--- a/super_gradients/training/models/detection_models/csp_darknet53.py
+++ b/super_gradients/training/models/detection_models/csp_darknet53.py
@@ -45,12 +45,9 @@ class Conv(nn.Module):
 class Bottleneck(nn.Module):
     # STANDARD BOTTLENECK
     def __init__(self, input_channels, output_channels, shortcut=True, groups=1,
-                 width_mult_factor: float = 1.0,
                  activation_func_type: type = nn.Hardswish):
         super().__init__()
 
-        input_channels = width_multiplier(input_channels, width_mult_factor)
-        output_channels = width_multiplier(output_channels, width_mult_factor)
         hidden_channels = output_channels
         self.cv1 = Conv(input_channels, hidden_channels, 1, 1, activation_func_type=activation_func_type)
         self.cv2 = Conv(hidden_channels, output_channels, 3, 1, groups=groups, activation_func_type=activation_func_type)
@@ -115,11 +112,9 @@ class BottleneckCSP(nn.Module):
 
 class SPP(nn.Module):
     # SPATIAL PYRAMID POOLING LAYER USED IN YOLOV3-SPP
-    def __init__(self, input_channels, output_channels, k=(5, 9, 13), width_mult_factor: float = 1.0):
+    def __init__(self, input_channels, output_channels, k=(5, 9, 13)):
         super().__init__()
 
-        input_channels = width_multiplier(input_channels, width_mult_factor)
-        output_channels = width_multiplier(output_channels, width_mult_factor)
         hidden_channels = input_channels // 2
         self.cv1 = Conv(input_channels, hidden_channels, 1, 1)
         self.cv2 = Conv(hidden_channels * (len(k) + 1), output_channels, 1, 1)
@@ -133,12 +128,10 @@ class SPP(nn.Module):
 class SPPF(nn.Module):
     # Spatial Pyramid Pooling - Fast (SPPF) layer for YOLOv5 by Glenn Jocher https://github.com/ultralytics/yolov5
     # equivalent to SPP(k=(5, 9, 13))
-    def __init__(self, input_channels, output_channels, k: int = 5, width_mult_factor: float = 1.0,
+    def __init__(self, input_channels, output_channels, k: int = 5,
                  activation_func_type: type = nn.SiLU):
         super().__init__()
 
-        input_channels = width_multiplier(input_channels, width_mult_factor)
-        output_channels = width_multiplier(output_channels, width_mult_factor)
         hidden_channels = input_channels // 2  # hidden channels
         self.cv1 = Conv(input_channels, hidden_channels, 1, 1, activation_func_type=activation_func_type)
         self.cv2 = Conv(hidden_channels * 4, output_channels, 1, 1, activation_func_type=activation_func_type)
@@ -153,11 +146,9 @@ class SPPF(nn.Module):
 
 class Focus(nn.Module):
     # FOCUS WH INFORMATION INTO C-SPACE
-    def __init__(self, input_channels, output_channels, kernel=1, stride=1, padding=None, groups=1,
-                 width_mult_factor: float = 1.0):
+    def __init__(self, input_channels, output_channels, kernel=1, stride=1, padding=None, groups=1):
         super().__init__()
 
-        output_channels = width_multiplier(output_channels, width_mult_factor)
         self.conv = Conv(input_channels * 4, output_channels, kernel, stride, padding, groups)
 
     def forward(self, x):  # x(b,c,w,h) -> y(b,4c,w/2,h/2)
@@ -189,11 +180,8 @@ class CSPDarknet53(SgModule):
 
         width_mult = lambda channels: width_multiplier(channels, self.width_mult_factor)
 
-        # # THE MODULES LIST IS APPROACHABLE FROM "OUTSIDE THE CLASS - SO WE CAN CHANGE IT'S STRUCTURE"
         self._modules_list = nn.ModuleList()
-
-        # THE MODULES LIST IS APPROACHABLE FROM "OUTSIDE THE CLASS - SO WE CAN CHANGE IT'S STRUCTURE"
-        self._modules_list.append(Focus(self.channels_in, 64, 3, width_mult_factor=self.width_mult_factor))  # 0
+        self._modules_list.append(Focus(self.channels_in, width_mult(64), 3))  # 0
         self._modules_list.append(Conv(width_mult(64), width_mult(128), 3, 2))  # 1
         self._modules_list.append(
             BottleneckCSP(128, 128, self.struct[0], width_mult_factor=self.width_mult_factor,
@@ -207,7 +195,7 @@ class CSPDarknet53(SgModule):
             BottleneckCSP(512, 512, self.struct[2], width_mult_factor=self.width_mult_factor,
                           depth_mult_factor=self.depth_mult_factor))  # 6
         self._modules_list.append(Conv(width_mult(512), width_mult(1024), 3, 2))  # 7
-        self._modules_list.append(SPP(1024, 1024, k=(5, 9, 13), width_mult_factor=self.width_mult_factor))  # 8
+        self._modules_list.append(SPP(width_mult(1024), width_mult(1024), k=(5, 9, 13)))  # 8
         self._modules_list.append(
             BottleneckCSP(1024, 1024, self.struct[3], False, width_mult_factor=self.width_mult_factor,
                           depth_mult_factor=self.depth_mult_factor))  # 9


### PR DESCRIPTION
Continue the change proposed in #12. This PR applies this change to `Detect`, `SPP`, `SPPF`, `Bottleneck` and `Focus`, #12 to `BottleneckCSP` and `C3`