### PR TITLE
POST_TRAINING callbacks before closing sg_logger

### DIFF
--- a/src/super_gradients/training/sg_model/sg_model.py
+++ b/src/super_gradients/training/sg_model/sg_model.py
@@ -930,15 +930,15 @@ class SgModel:
                 if torch.distributed.is_initialized():
                     torch.distributed.destroy_process_group()
 
+            # PHASE.TRAIN_END
+            self.phase_callback_handler(Phase.POST_TRAINING, context)
+
             if not self.ddp_silent_mode:
                 if self.model_checkpoints_location != 'local':
                     logger.info('[CLEANUP] - Saving Checkpoint files')
                     self.sg_logger.upload()
 
                 self.sg_logger.close()
-
-            # PHASE.TRAIN_END
-            self.phase_callback_handler(Phase.POST_TRAINING, context)
 
     def _initialize_mixed_precision(self, mixed_precision_enabled: bool):
         # SCALER IS ALWAYS INITIALIZED BUT IS DISABLED IF MIXED PRECISION WAS NOT SET


### PR DESCRIPTION
This change should allow POST_TRAINING phase callbacks to still use the sg_logger before it is closed