### PR TITLE
fix stdc context conversion

### DIFF
--- a/src/super_gradients/training/models/segmentation_models/stdc.py
+++ b/src/super_gradients/training/models/segmentation_models/stdc.py
@@ -304,8 +304,10 @@ class ContextEmbeddingFixedSize(ContextEmbeddingOnline):
 
     @classmethod
     def from_context_embedding_online(cls, ce_online: ContextEmbeddingOnline, upsample_size: Union[list, tuple]):
-        return ContextEmbeddingFixedSize(in_channels=ce_online.in_channels, out_channels=ce_online.out_channels,
-                                         upsample_size=upsample_size)
+        context = ContextEmbeddingFixedSize(in_channels=ce_online.in_channels, out_channels=ce_online.out_channels,
+                                            upsample_size=upsample_size)
+        context.load_state_dict(ce_online.state_dict())
+        return context
 
     def forward(self, x):
         return self.context_embedding(x)

--- a/src/super_gradients/training/models/segmentation_models/stdc.py
+++ b/src/super_gradients/training/models/segmentation_models/stdc.py
@@ -306,6 +306,8 @@ class ContextEmbeddingFixedSize(ContextEmbeddingOnline):
     def from_context_embedding_online(cls, ce_online: ContextEmbeddingOnline, upsample_size: Union[list, tuple]):
         context = ContextEmbeddingFixedSize(in_channels=ce_online.in_channels, out_channels=ce_online.out_channels,
                                             upsample_size=upsample_size)
+        # keep training mode state as original module
+        context.train(ce_online.training)
         context.load_state_dict(ce_online.state_dict())
         return context
 


### PR DESCRIPTION
Fixed when replacing to static size context embedding, the weights are transferred to the new module.