### PR TITLE
Init optimizer with class type

### DIFF
--- a/src/super_gradients/training/sg_model/sg_model.py
+++ b/src/super_gradients/training/sg_model/sg_model.py
@@ -836,11 +836,14 @@ class SgModel:
             self.best_metric = -1 * np.inf if self.greater_metric_to_watch_is_better else np.inf
             load_opt_params = False
 
-        if isinstance(self.training_params.optimizer, str):
+        optimizer_param = self.training_params.optimizer
+        # if is a string or a torch.optim.Optimizer class type
+        if isinstance(optimizer_param, str) or\
+                (isinstance(optimizer_param, type) and issubclass(optimizer_param, torch.optim.Optimizer)):
             self.optimizer = build_optimizer(net=self.net, lr=self.training_params.initial_lr,
                                              training_params=self.training_params)
-        elif isinstance(self.training_params.optimizer, torch.optim.Optimizer):
-            self.optimizer = self.training_params.optimizer
+        elif isinstance(optimizer_param, torch.optim.Optimizer):
+            self.optimizer = optimizer_param
         else:
             raise UnsupportedOptimizerFormat()
 

--- a/src/super_gradients/training/utils/optimizer_utils.py
+++ b/src/super_gradients/training/utils/optimizer_utils.py
@@ -79,7 +79,10 @@ def build_optimizer(net, lr, training_params):
         :param lr: initial learning rate
         :param training_params: training_parameters
     """
-    optimizer_cls = OptimizersTypeFactory().get(training_params.optimizer)
+    if isinstance(training_params.optimizer, str):
+        optimizer_cls = OptimizersTypeFactory().get(training_params.optimizer)
+    else:
+        optimizer_cls = training_params.optimizer
     default_optimizer_params = OPTIMIZERS_DEFAULT_PARAMS[optimizer_cls] if optimizer_cls in OPTIMIZERS_DEFAULT_PARAMS else {}
     training_params.optimizer_params = get_param(training_params, 'optimizer_params', default_optimizer_params)
 


### PR DESCRIPTION
Add the option to pass a `torch.optim.Optimizer` class type in traininig params to initiate an optimizer object through the `build_optimizer`.

This way a custom / not supported optimizer class can be passed, while still make use of the utils functions `initialize_param_groups` and `zero_weight_decay_on_bias_and_bn`