### PR TITLE
fix: Build a correct YOLOX-nano with depthwise separable convs

### DIFF
--- a/src/super_gradients/recipes/arch_params/yolo_arch_params.yaml
+++ b/src/super_gradients/recipes/arch_params/yolo_arch_params.yaml
@@ -23,4 +23,5 @@ nms_iou: 0.45  # When add_nms is True IoU threshold for NMS algorithm
 yolo_type: 'yoloV5'   # Type of yolo to build: 'yoloV5' and 'yoloX' are supported
 yolo_version: 'v6.0'  # Release version of Ultralytics to built a model from: v.6.0 and v3.0 are supported
 stem_type: None,  # 'focus' and '6x6' are supported, by default is defined by yolo_type and yolo_version
+depthwise: False  # use depthwise separable convolutions all over the model
 _convert_: all

--- a/src/super_gradients/recipes/arch_params/yolox_nano_arch_params.yaml
+++ b/src/super_gradients/recipes/arch_params/yolox_nano_arch_params.yaml
@@ -10,3 +10,4 @@ yolo_type: 'yoloX'
 
 depth_mult_factor: 0.33
 width_mult_factor: 0.25
+depthwise: true

--- a/src/super_gradients/training/models/detection_models/csp_darknet53.py
+++ b/src/super_gradients/training/models/detection_models/csp_darknet53.py
@@ -83,7 +83,8 @@ class DepthWiseConv(nn.Module):
                  padding: int = None):
         super().__init__()
 
-        self.dconv = Conv(input_channels, input_channels, kernel, stride, activation_type, padding, input_channels)
+        self.dconv = Conv(input_channels, input_channels, kernel, stride, activation_type, padding,
+                          groups=input_channels)
         self.conv = Conv(input_channels, output_channels, 1, 1, activation_type)
 
     def forward(self, x):

--- a/src/super_gradients/training/models/detection_models/csp_darknet53.py
+++ b/src/super_gradients/training/models/detection_models/csp_darknet53.py
@@ -77,14 +77,29 @@ class Conv(nn.Module):
         return self.act(self.conv(x))
 
 
-class Bottleneck(nn.Module):
-    # STANDARD BOTTLENECK
-    def __init__(self, input_channels, output_channels, shortcut: bool, activation_type: Type[nn.Module], groups=1):
+class DepthWiseConv(nn.Module):
+    # STANDARD CONVOLUTION
+    def __init__(self, input_channels, output_channels, kernel, stride, activation_type: Type[nn.Module],
+                 padding: int = None):
         super().__init__()
 
+        self.dconv = Conv(input_channels, input_channels, kernel, stride, activation_type, padding, input_channels)
+        self.conv = Conv(input_channels, output_channels, 1, 1, activation_type)
+
+    def forward(self, x):
+        return self.conv(self.dconv(x))
+
+
+class Bottleneck(nn.Module):
+    # STANDARD BOTTLENECK
+    def __init__(self, input_channels, output_channels, shortcut: bool, activation_type: Type[nn.Module],
+                 depthwise=False):
+        super().__init__()
+
+        ConvBlock = DepthWiseConv if depthwise else Conv
         hidden_channels = output_channels
         self.cv1 = Conv(input_channels, hidden_channels, 1, 1, activation_type)
-        self.cv2 = Conv(hidden_channels, output_channels, 3, 1, activation_type, groups=groups)
+        self.cv2 = ConvBlock(hidden_channels, output_channels, 3, 1, activation_type)
         self.add = shortcut and input_channels == output_channels
 
     def forward(self, x):
@@ -94,7 +109,7 @@ class Bottleneck(nn.Module):
 class C3(nn.Module):
     # CSP Bottleneck with 3 convolutions https://github.com/ultralytics/yolov5
     def __init__(self, input_channels, output_channels, bottleneck_blocks_num, activation_type: Type[nn.Module],
-                 shortcut=True, groups=1, expansion=0.5):
+                 shortcut=True, depthwise=False, expansion=0.5):
         super().__init__()
 
         hidden_channels = int(output_channels * expansion)
@@ -102,7 +117,7 @@ class C3(nn.Module):
         self.cv1 = Conv(input_channels, hidden_channels, 1, 1, activation_type)
         self.cv2 = Conv(input_channels, hidden_channels, 1, 1, activation_type)
         self.cv3 = Conv(2 * hidden_channels, output_channels, 1, 1, activation_type)
-        self.m = nn.Sequential(*[Bottleneck(hidden_channels, hidden_channels, shortcut, activation_type, groups=groups)
+        self.m = nn.Sequential(*[Bottleneck(hidden_channels, hidden_channels, shortcut, activation_type, depthwise)
                                  for _ in range(bottleneck_blocks_num)])
 
     def forward(self, x):
@@ -112,7 +127,7 @@ class C3(nn.Module):
 class BottleneckCSP(nn.Module):
     # CSP Bottleneck https://github.com/WongKinYiu/CrossStagePartialNetworks
     def __init__(self, input_channels, output_channels, bottleneck_blocks_num, activation_type: Type[nn.Module],
-                 shortcut=True, groups=1, expansion=0.5):
+                 shortcut=True, depthwise=False, expansion=0.5):
         super().__init__()
 
         hidden_channels = int(output_channels * expansion)
@@ -123,7 +138,7 @@ class BottleneckCSP(nn.Module):
         self.cv4 = Conv(2 * hidden_channels, output_channels, 1, 1, activation_type)
         self.bn = nn.BatchNorm2d(2 * hidden_channels)  # APPLIED TO CAT(CV2, CV3)
         self.act = nn.LeakyReLU(0.1, inplace=True)
-        self.m = nn.Sequential(*[Bottleneck(hidden_channels, hidden_channels, shortcut, activation_type, groups=groups)
+        self.m = nn.Sequential(*[Bottleneck(hidden_channels, hidden_channels, shortcut, activation_type, depthwise)
                                  for _ in range(bottleneck_blocks_num)])
 
     def forward(self, x):
@@ -200,10 +215,12 @@ class CSPDarknet53(SgModule):
         channels_in = get_param(arch_params, 'channels_in', 3)
         yolo_version = get_param(arch_params, 'yolo_version', 'v6.0')
         yolo_type = get_param(arch_params, 'yolo_type', 'yoloV5')
+        depthwise = get_param(arch_params, 'depthwise', False)
 
         struct, block, activation_type, width_mult, depth_mult = get_yolo_version_params(yolo_version, yolo_type,
                                                                                          width_mult_factor,
                                                                                          depth_mult_factor)
+        ConvBlock = Conv if not depthwise else DepthWiseConv
 
         struct = [depth_mult(s) for s in struct]
         self._modules_list = nn.ModuleList()
@@ -215,18 +232,23 @@ class CSPDarknet53(SgModule):
         else:
             raise NotImplementedError(f'One of {yolo_type} yolo type or {yolo_version} yolo version is not supported')
 
-        self._modules_list.append(Conv(width_mult(64), width_mult(128), 3, 2, activation_type))                      # 1
-        self._modules_list.append(block(width_mult(128), width_mult(128), struct[0], activation_type))               # 2
-        self._modules_list.append(Conv(width_mult(128), width_mult(256), 3, 2, activation_type))                     # 3
-        self._modules_list.append(block(width_mult(256), width_mult(256), struct[1], activation_type))               # 4
-        self._modules_list.append(Conv(width_mult(256), width_mult(512), 3, 2, activation_type))                     # 5
-        self._modules_list.append(block(width_mult(512), width_mult(512), struct[2], activation_type))               # 6
-        self._modules_list.append(Conv(width_mult(512), width_mult(1024), 3, 2, activation_type))                    # 7
+        self._modules_list.append(ConvBlock(width_mult(64), width_mult(128), 3, 2, activation_type))                 # 1
+        self._modules_list.append(
+            block(width_mult(128), width_mult(128), struct[0], activation_type, depthwise=depthwise))                # 2
+        self._modules_list.append(ConvBlock(width_mult(128), width_mult(256), 3, 2, activation_type))                # 3
+        self._modules_list.append(
+            block(width_mult(256), width_mult(256), struct[1], activation_type, depthwise=depthwise))                # 4
+        self._modules_list.append(ConvBlock(width_mult(256), width_mult(512), 3, 2, activation_type))                # 5
+        self._modules_list.append(
+            block(width_mult(512), width_mult(512), struct[2], activation_type, depthwise=depthwise))                # 6
+        self._modules_list.append(ConvBlock(width_mult(512), width_mult(1024), 3, 2, activation_type))               # 7
         if yolo_type == 'yoloX' or yolo_version == 'v3.0':
             self._modules_list.append(SPP(width_mult(1024), width_mult(1024), (5, 9, 13), activation_type))          # 8
-            self._modules_list.append(block(width_mult(1024), width_mult(1024), struct[3], activation_type, False))  # 9
+            self._modules_list.append(
+                block(width_mult(1024), width_mult(1024), struct[3], activation_type, False, depthwise=depthwise))   # 9
         elif yolo_version == 'v6.0':
-            self._modules_list.append(block(width_mult(1024), width_mult(1024), struct[3], activation_type))         # 8
+            self._modules_list.append(
+                block(width_mult(1024), width_mult(1024), struct[3], activation_type, depthwise=depthwise))          # 8
             self._modules_list.append(SPPF(width_mult(1024), width_mult(1024), 5, activation_type))                  # 9
         else:
             raise NotImplementedError(f'One of {yolo_type} yolo type or {yolo_version} yolo version is not supported')

--- a/src/super_gradients/training/models/detection_models/yolov5_base.py
+++ b/src/super_gradients/training/models/detection_models/yolov5_base.py
@@ -280,7 +280,7 @@ class YoLoV5Head(nn.Module):
             strides = anchors.stride
             self._modules_list.append(
                 DetectX(num_classes, strides, activation_type, channels=[width_mult(v) for v in (256, 512, 1024)],
-                        depthwise=arch_params.depthwise))  # 24
+                        depthwise=depthwise))  # 24
 
         self.anchors = anchors
         self.width_mult = width_mult

--- a/src/super_gradients/training/models/detection_models/yolox.py
+++ b/src/super_gradients/training/models/detection_models/yolox.py
@@ -7,6 +7,7 @@ class YoloX_N(YoLoV5Base):
         arch_params.depth_mult_factor = 0.33
         arch_params.width_mult_factor = 0.25
         arch_params.yolo_type = 'yoloX'
+        arch_params.depthwise = True
         super().__init__(backbone=YoLoV5DarknetBackbone, arch_params=arch_params)
 
 


### PR DESCRIPTION
Adding new arch_param 'depthwise': False, which is needed for YOLOX-nano. When its True the following layers are replaced with depthwise-separable ones:
* `Conv`s* and blocks** in the backbone (all except `Focus`);
* Blocks and 2 last downsizing  `Conv`s in the head;
* `Conv`s in two branches in `DetectX` (all except Stem and predicting layers).

*Depthwise-separable Conv = `DepthWiseConv`
**Depthwise-separable block = a block with `DepthWiseConv` in Bottleneck

Changes in `C3` and `BottleneckCSP aren't backward-compatible, but these modules are used only in yolov5_base.py and csp_darknet53.py anyway.
