### PR TITLE
fix: Get people back their own class

### DIFF
--- a/src/super_gradients/training/losses/ssd_loss.py
+++ b/src/super_gradients/training/losses/ssd_loss.py
@@ -68,7 +68,7 @@ class SSDLoss(_Loss):
             mask = values > self.iou_thresh
 
             target_locations[:, mask] = targets[indices[mask], 2:].T
-            target_labels[mask] = targets[indices[mask], 1]
+            target_labels[mask] = targets[indices[mask], 1] + 1
 
         return target_locations, target_labels
 

--- a/src/super_gradients/training/utils/ssd_utils.py
+++ b/src/super_gradients/training/utils/ssd_utils.py
@@ -202,9 +202,4 @@ class SSDPostPredictCallback(DetectionPostPredictionCallback):
             nms_res = matrix_non_max_suppression(nms_input, conf_thres=self.conf,
                                                  max_num_of_detections=self.max_predictions)
 
-        # NMS OUTPUT A 0-BASED CLASS LABEL, BUT SSD WORKS WITH 1-BASED CLASS LABEL
-        for t in nms_res:
-            if t is not None:
-                t[:, 5] += 1
-
         return nms_res


### PR DESCRIPTION
Our SSD never predicts people because of the collapse between the background and person category. The fix can be achieved with either + 1 on targets or offset in the dataset. From these options I find +1 preferable, because I think it's purely about the loss. Especially since the post-prediction callback is meant to utilize the background class and get rid of it. So predicted classes will be 0-based, and so should be targets imo. 
One more reason: 0-based classes are consistent with [COCO_DETECTION_CLASSES_LIST](https://github.com/Deci-AI/super-gradients/blob/cf08b5dcb0a92b9e462731da447786aa7d22f2aa/src/super_gradients/training/datasets/datasets_conf.py#L1)

As for the part of the code removed in the callback, it is a patch for the bug explained above, so I'm removing it.
For clarity, the patch allowed to restore other classes to their correct index, but never a person.