### PR TITLE
fix: Support any model width multiplier

### DIFF
--- a/src/super_gradients/recipes/arch_params/yolo_arch_params.yaml
+++ b/src/super_gradients/recipes/arch_params/yolo_arch_params.yaml
@@ -9,12 +9,15 @@ anchors:
 num_classes: 80  # Number of classes to predict
 depth_mult_factor: 1.0  # depth multiplier for the entire model, overridden for predefined YoloV5S, YoloV5M, YoloV5L
 width_mult_factor: 1.0  # width multiplier for the entire model, overridden for predefined YoloV5S, YoloV5M, YoloV5L
-channels_in: 3  # # of classes the model predicts
+channels_in: 3  # Number of channels in the input image
 skip_connections_list: [[12, [6]], [16, [4]], [19, [14]], [22, [10]], [24, [17, 20]]]
 # A list defining skip connections. format is [target: [source1, source2, ...]]. Each item defines a skip
 # connection from all sources to the target according to the layers index (count starts from the backbone)
-connection_layers_input_channel_size: [1024, 1024, 512]
-# default number off channels for the connecting points between the backbone and the head
+backbone_connection_channels: [1024, 512, 256]  # width of backbone channels that are concatenated with the head
+scaled_backbone_width: True  # True if width_mult_factor is applied to the backbone
+# (is the case with the default backbones)
+# which means that backbone_connection_channels should be used with a width_mult_factor
+# False if backbone_connection_channels should be used as is
 fuse_conv_and_bn: False  # Fuse sequential Conv + B.N layers into a single one
 add_nms: False  # Add the NMS module to the computational graph
 nms_conf: 0.25  # When add_nms is True during NMS predictions with confidence lower than this will be discarded

--- a/src/super_gradients/training/models/detection_models/yolov5_base.py
+++ b/src/super_gradients/training/models/detection_models/yolov5_base.py
@@ -27,13 +27,15 @@ DEFAULT_YOLO_ARCH_PARAMS = {
     'num_classes': 80,  # Number of classes to predict
     'depth_mult_factor': 1.0,  # depth multiplier for the entire model
     'width_mult_factor': 1.0,  # width multiplier for the entire model
-    'channels_in': 3,  # # of classes the model predicts
+    'channels_in': 3,  # Number of channels in the input image
     'skip_connections_list': [(12, [6]), (16, [4]), (19, [14]), (22, [10]), (24, [17, 20])],
     # A list defining skip connections. format is '[target: [source1, source2, ...]]'. Each item defines a skip
     # connection from all sources to the target according to the layer's index (count starts from the backbone)
-    'backbone_connection_channels': [1024, 512, 256],
-    'scale_backbone_width': True,
-    # default number off channels for the connecting points between the backbone and the head
+    'backbone_connection_channels': [1024, 512, 256],  # width of backbone channels that are concatenated with the head
+    # True if width_mult_factor is applied to the backbone (is the case with the default backbones)
+    # which means that backbone_connection_channels should be used with a width_mult_factor
+    # False if backbone_connection_channels should be used as is
+    'scaled_backbone_width': True,
     'fuse_conv_and_bn': False,  # Fuse sequential Conv + B.N layers into a single one
     'add_nms': False,  # Add the NMS module to the computational graph
     'nms_conf': 0.25,  # When add_nms is True during NMS predictions with confidence lower than this will be discarded
@@ -247,7 +249,7 @@ class YoLoV5Head(nn.Module):
                                                                                     arch_params.width_mult_factor,
                                                                                     arch_params.depth_mult_factor)
 
-        backbone_connector = [width_mult(c) if arch_params.scale_backbone_width else c
+        backbone_connector = [width_mult(c) if arch_params.scaled_backbone_width else c
                              for c in arch_params.backbone_connection_channels]
 
         DownConv = DepthWiseConv if depthwise else Conv

--- a/tests/unit_tests/yolov5_unit_test.py
+++ b/tests/unit_tests/yolov5_unit_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import torch
 import torch.nn as nn
 
@@ -64,6 +65,17 @@ class TestYoloV5(unittest.TestCase):
             optimizer_params_total = sum(p.numel() for g in param_groups for _, p in g['named_params'])
 
             self.assertEqual(params_total, optimizer_params_total)
+
+    def test_custom_width_mult(self):
+        """
+        Test that yolo can be created with various width multiplies without rounding issues
+        """
+        dummy_input = torch.randn(1, 3, 320, 320)
+
+        with torch.no_grad():
+            for width in np.arange(0.77, 1.4, 0.07):
+                yolov5_custom = Custom_YoLoV5(arch_params=HpmStruct(num_classes=10, width_mult_factor=width))
+                self.assertIsNotNone(yolov5_custom(dummy_input))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixing the usage of width multiplier for any YOLO-based model. We used to be able to construct only certain multiplier which aren't know in advance, but now any can be used, which is verified in the test I'm adding.

The problem was 2-fold:
1. Say someone attempts to use width_mult of 1.33. In this case the last head layer had input width_mult(1024), which is meant operate on two feature maps of width_mult(512) concatenated prior. But `int(1.33*512)` =  680, so the width after concat will be 680*2 = 1360, but `int(1.33*1024)` =  1361, which creates channel mismatch.
2. It's problematic to aways do `width_mult(connector[1])` where connector is a pre-calculated number of channels after concat between a head and a backbone layers. In such case using this head with a fixed backbone (no width scaling in it) becomes very cumbersome. You have to multiply backbone channels with a width back and forth to reach a correct connector (obviously not backbone layers per se, just numbers). This causes rounding issues and makes many multipliers impossible to use.

Simple solution:
Define input channels of layers after concat as a sum of two scaled* inputs, allow not scaling the backbone   

*scaled = width multiplier applied