### PR TITLE
Fix failing yolo param groups test

### DIFF
--- a/tests/unit_tests/yolov5_unit_test.py
+++ b/tests/unit_tests/yolov5_unit_test.py
@@ -60,7 +60,7 @@ class TestYoloV5(unittest.TestCase):
             yolo_model = yolo_cls(self.arch_params)
             yolo_model.train()
 
-            params_total = sum(p.numel() for p in yolo_model.parameters())
+            params_total = sum(p.numel() for p in yolo_model.parameters() if p.requires_grad)
             param_groups = yolo_model.initialize_param_groups(0.1, train_params)
             optimizer_params_total = sum(p.numel() for g in param_groups for _, p in g['named_params'])
 


### PR DESCRIPTION
This test is supposed to make sure that yolo's `initialize_param_groups(...)` method doesn't leave some parameters out. Can happen if you change an architecture, but forget about this function. But params that don't require grad, like anchors, etc, shouldn't be in optimizer's params. That's a fix