### PR TITLE
state moved to metrics device

### DIFF
--- a/src/super_gradients/training/metrics/detection_metrics.py
+++ b/src/super_gradients/training/metrics/detection_metrics.py
@@ -5,6 +5,7 @@ import torch
 from torchmetrics import Metric
 
 import super_gradients
+from super_gradients.training.utils import tensor_container_to_device
 from super_gradients.training.utils.detection_utils import compute_detection_matching, compute_detection_metrics,\
     calc_batch_prediction_accuracy
 from super_gradients.training.utils.detection_utils import DetectionPostPredictionCallback, IouThreshold
@@ -197,7 +198,7 @@ class DetectionMetricsV2(Metric):
          num_cls:                  Number of classes.
          post_prediction_callback: DetectionPostPredictionCallback to be applied on net's output prior
                                    to the metric computation (NMS).
-         normalize_targets:        Whether to normalize bbox coordinates by image size (default=True).
+         normalize_targets:        Whether to normalize bbox coordinates by image size (default=False).
 
          iou_thresholds:    IoU threshold to compute the mAP (default=torch.linspace(0.5, 0.95, 10)).
          recall_thresholds: Recall threshold to compute the mAP (default=torch.linspace(0, 1, 101)).
@@ -271,12 +272,11 @@ class DetectionMetricsV2(Metric):
 
         if len(accumulated_matching_info):
             matching_info_tensors = [torch.cat(x, 0) for x in list(zip(*accumulated_matching_info))]
-            device = matching_info_tensors[0].device
-            self.recall_thresholds = self.recall_thresholds.to(device)
+            self.recall_thresholds = self.recall_thresholds.to(self.device)
 
             # shape (n_class, nb_iou_thresh)
             ap, precision, recall, f1, unique_classes = compute_detection_metrics(
-                *matching_info_tensors, device=device, recall_thresholds=self.recall_thresholds,
+                *matching_info_tensors, device=self.device, recall_thresholds=self.recall_thresholds,
                 score_threshold=self.score_threshold)
 
             # Precision, recall and f1 are computed for smallest IoU threshold (usually 0.5), averaged over classes
@@ -309,4 +309,5 @@ class DetectionMetricsV2(Metric):
             for state_dict in gathered_state_dicts:
                 matching_info += state_dict["matching_info"]
 
+            matching_info = tensor_container_to_device(matching_info, device=self.device)
             setattr(self, "matching_info", matching_info)


### PR DESCRIPTION
Synchronized metric state tensors are on different devices in DDP which causes the training to crash in compute().