### PR TITLE
Support for reading pretrained YoloX models with old blocks

### DIFF
--- a/src/super_gradients/training/models/detection_models/yolov5_base.py
+++ b/src/super_gradients/training/models/detection_models/yolov5_base.py
@@ -363,10 +363,8 @@ class YoLoV5Base(SgModule):
         super().__init__()
         # DEFAULT PARAMETERS TO BE OVERWRITTEN BY DUPLICATES THAT APPEAR IN arch_params
         self.arch_params = HpmStruct(**DEFAULT_YOLO_ARCH_PARAMS)
-        if get_param(arch_params, 'yolo_type', 'yoloV5') != 'yoloX':
-            self.arch_params.anchors = COCO_DETECTION_80_CLASSES_BBOX_ANCHORS
-        else:
-            self.arch_params.anchors = ANCHORSLESS_DUMMY_ANCHORS
+        # FIXME: REMOVE anchors ATTRIBUTE, WHICH HAS NO MEANING OTHER THAN COMPATIBILITY.
+        self.arch_params.anchors = COCO_DETECTION_80_CLASSES_BBOX_ANCHORS
         self.arch_params.override(**arch_params.to_dict())
         self.arch_params.skip_connections_dict = {k: v for k, v in self.arch_params.skip_connections_list}
 

--- a/src/super_gradients/training/utils/checkpoint_utils.py
+++ b/src/super_gradients/training/utils/checkpoint_utils.py
@@ -139,7 +139,8 @@ def adapt_state_dict_to_fit_model_layer_names(model_state_dict: dict, source_ckp
         :param model_state_dict:               the model state_dict
         :param source_ckpt:                         checkpoint dict
         :param exclude                  optional list for excluded layers
-        :param solver:                  callable that returns a desired weight for (ckpt_key, ckpt_val, model_key, model_val)
+        :param solver:                  callable with signature (ckpt_key, ckpt_val, model_key, model_val)
+                                        that returns a desired weight for ckpt_val.
         :return: renamed checkpoint dict (if possible)
     """
     if 'net' in source_ckpt.keys():
@@ -229,7 +230,8 @@ def _yolox_ckpt_solver(ckpt_key, ckpt_val, model_key, model_val):
     """
     Helper method for reshaping old pretrained checkpoint's focus weights to 6x6 conv weights.
     """
-    if ckpt_key == 'module._backbone._modules_list.0.conv.conv.weight' and model_key == '_backbone._modules_list.0.conv.weight':
+
+    if ckpt_val.shape != model_val.shape and ckpt_key == 'module._backbone._modules_list.0.conv.conv.weight' and model_key == '_backbone._modules_list.0.conv.weight':
         model_val.data[:, :, ::2, ::2] = ckpt_val.data[:, :3]
         model_val.data[:, :, 1::2, ::2] = ckpt_val.data[:, 3:6]
         model_val.data[:, :, ::2, 1::2] = ckpt_val.data[:, 6:9]

--- a/src/super_gradients/training/utils/checkpoint_utils.py
+++ b/src/super_gradients/training/utils/checkpoint_utils.py
@@ -132,13 +132,14 @@ def read_ckpt_state_dict(ckpt_path: str, device="cpu"):
     return state_dict
 
 
-def adapt_state_dict_to_fit_model_layer_names(model_state_dict: dict, source_ckpt: dict, exclude: list = []):
+def adapt_state_dict_to_fit_model_layer_names(model_state_dict: dict, source_ckpt: dict, exclude: list = [], solver: callable=None):
     """
     Given a model state dict and source checkpoints, the method tries to correct the keys in the model_state_dict to fit
     the ckpt in order to properly load the weights into the model. If unsuccessful - returns None
         :param model_state_dict:               the model state_dict
         :param source_ckpt:                         checkpoint dict
-        :exclude                  optional list for excluded layers
+        :param exclude                  optional list for excluded layers
+        :param solver:                  callable that returns a desired weight for (ckpt_key, ckpt_val, model_key, model_val)
         :return: renamed checkpoint dict (if possible)
     """
     if 'net' in source_ckpt.keys():
@@ -146,6 +147,8 @@ def adapt_state_dict_to_fit_model_layer_names(model_state_dict: dict, source_ckp
     model_state_dict_excluded = {k: v for k, v in model_state_dict.items() if not any(x in k for x in exclude)}
     new_ckpt_dict = {}
     for (ckpt_key, ckpt_val), (model_key, model_val) in zip(source_ckpt.items(), model_state_dict_excluded.items()):
+        if solver is not None:
+            ckpt_val = solver(ckpt_key, ckpt_val, model_key, model_val)
         if ckpt_val.shape != model_val.shape:
             raise ValueError(f'ckpt layer {ckpt_key} with shape {ckpt_val.shape} does not match {model_key}'
                              f' with shape {model_val.shape} in the model')
@@ -222,6 +225,20 @@ class MissingPretrainedWeightsException(Exception):
         self.message = "Missing pretrained wights: " + desc
         super().__init__(self.message)
 
+def _yolox_ckpt_solver(ckpt_key, ckpt_val, model_key, model_val):
+    """
+    Helper method for reshaping old pretrained checkpoint's focus weights to 6x6 conv weights.
+    """
+    if ckpt_key == 'module._backbone._modules_list.0.conv.conv.weight' and model_key == '_backbone._modules_list.0.conv.weight':
+        model_val.data[:, :, ::2, ::2] = ckpt_val.data[:, :3]
+        model_val.data[:, :, 1::2, ::2] = ckpt_val.data[:, 3:6]
+        model_val.data[:, :, ::2, 1::2] = ckpt_val.data[:, 6:9]
+        model_val.data[:, :, 1::2, 1::2] = ckpt_val.data[:, 9:12]
+        replacement = model_val
+    else:
+        replacement = ckpt_val
+
+    return replacement
 
 def load_pretrained_weights(model: torch.nn.Module, architecture: str, pretrained_weights: str):
 
@@ -242,5 +259,6 @@ def load_pretrained_weights(model: torch.nn.Module, architecture: str, pretraine
     pretrained_state_dict = load_state_dict_from_url(url=url, map_location=map_location, file_name=unique_filename)
     if 'ema_net' in pretrained_state_dict.keys():
         pretrained_state_dict['net'] = pretrained_state_dict['ema_net']
-    adapted_pretrained_state_dict = adapt_state_dict_to_fit_model_layer_names(model_state_dict=model.state_dict(), source_ckpt=pretrained_state_dict)
+    solver = _yolox_ckpt_solver if "yolox" in architecture else None
+    adapted_pretrained_state_dict = adapt_state_dict_to_fit_model_layer_names(model_state_dict=model.state_dict(), source_ckpt=pretrained_state_dict, solver=solver)
     model.load_state_dict(adapted_pretrained_state_dict['net'], strict=False)

--- a/tests/unit_tests/yolox_unit_test.py
+++ b/tests/unit_tests/yolox_unit_test.py
@@ -39,9 +39,6 @@ class TestYOLOX(unittest.TestCase):
                 output_augment = yolo_model(dummy_input)
                 self.assertIsNotNone(output_augment)
 
-                # MODEL IS ANCHORLESS
-                self.assertTrue(yolo_model._head.anchors.num_anchors == 0)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Old Focus block weights reshaped when reading ckpt to 6x6 conversation weights.
- Anchors are fixed to old COCO Anchors for compatibility and will be removed in the future.