### PR TITLE
Hotfix detection cache: Add hash in name when caching

### DIFF
--- a/src/super_gradients/training/datasets/detection_datasets/detection_dataset.py
+++ b/src/super_gradients/training/datasets/detection_datasets/detection_dataset.py
@@ -235,7 +235,6 @@ class DetectionDataset(Dataset):
             logger.info("Caching images for the first time. Be aware that this will stay in the disk until you delete it yourself.")
             NUM_THREADs = min(8, os.cpu_count())
             loaded_images = ThreadPool(NUM_THREADs).imap(func=lambda x: self._load_resized_img(x), iterable=range(len(self)))
-            # loaded_images = map(lambda x: self._load_resized_img(x), range(len(self)))
 
             # Initialize placeholder for images
             cached_imgs = np.memmap(str(img_resized_cache_path), shape=(len(self), max_h, max_w, 3),

--- a/src/super_gradients/training/datasets/detection_datasets/detection_dataset.py
+++ b/src/super_gradients/training/datasets/detection_datasets/detection_dataset.py
@@ -73,7 +73,7 @@ class DetectionDataset(Dataset):
             output_fields: List[str] = None,
     ):
         """Detection dataset.
-self.input_dim, self.max_num_samples, self.classes, self.ignore_empty_annotations, len(self.annotations)
+
         :param data_dir:                Where the data is stored
         :param input_dim:               Image size (when loaded, before transforms).
         :param original_target_format:  Format of targets stored on disk. raw data format, the output format might

--- a/tests/deci_core_unit_test_suite_runner.py
+++ b/tests/deci_core_unit_test_suite_runner.py
@@ -26,6 +26,7 @@ from tests.unit_tests.forward_pass_prep_fn_test import ForwardpassPrepFNTest
 from tests.unit_tests.mask_loss_test import MaskAttentionLossTest
 from tests.unit_tests.detection_sub_sampling_test import TestDetectionDatasetSubsampling
 from tests.unit_tests.detection_sub_classing_test import TestDetectionDatasetSubclassing
+from tests.unit_tests.detection_caching import TestDetectionDatasetCaching
 
 
 class CoreUnitTestSuiteRunner:
@@ -74,6 +75,7 @@ class CoreUnitTestSuiteRunner:
         self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(IoULossTest))
         self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(TestDetectionDatasetSubsampling))
         self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(TestDetectionDatasetSubclassing))
+        self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(TestDetectionDatasetCaching))
 
     def _add_modules_to_end_to_end_tests_suite(self):
         """

--- a/tests/unit_tests/detection_caching.py
+++ b/tests/unit_tests/detection_caching.py
@@ -80,6 +80,7 @@ class TestDetectionDatasetCaching(unittest.TestCase):
         """Check that after the first time a dataset is called with specific params,
         the next time it will call the saved array instead of building it."""
         self._empty_cache()
+        self.assertEqual(0, self._count_cached_array())
 
         _ = DummyDetectionDataset(input_dim=(640, 512), ignore_empty_annotations=True,
                                   cache=True, cache_path=self.cache_dir, data_dir='/home/')

--- a/tests/unit_tests/detection_caching.py
+++ b/tests/unit_tests/detection_caching.py
@@ -19,10 +19,14 @@ class DummyDetectionDataset(DetectionDataset):
         return self.n_samples
 
     def _load_annotation(self, sample_id: int) -> dict:
-        """Every image is made of one target, with label sample_id%len(all_classes_list)
+        """Every image is made of one target, with label sample_id % len(all_classes_list) and
+        a seed to allow the random image to the same for a given sample_id
         """
         cls_id = sample_id % len(self.all_classes_list)
-        return {"img_path": str(sample_id), "target": np.array([[0, 0, 10, 10, cls_id]]), "resized_img_shape": (self.image_size[0], self.image_size[1]), "seed": sample_id}
+        return {"img_path": str(sample_id),
+                "target": np.array([[0, 0, 10, 10, cls_id]]),
+                "resized_img_shape": self.image_size,
+                "seed": sample_id}
 
     # We overwrite this to fake images
     def _load_image(self, index: int) -> np.ndarray:
@@ -57,6 +61,7 @@ class TestDetectionDatasetCaching(unittest.TestCase):
 
         for first_dataset, second_dataset in zip(datasets[:-1], datasets[1:]):
             self.assertFalse(np.array_equal(first_dataset.cached_imgs, second_dataset.cached_imgs))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit_tests/detection_caching.py
+++ b/tests/unit_tests/detection_caching.py
@@ -1,0 +1,62 @@
+import unittest
+import numpy as np
+
+from super_gradients.training.datasets import DetectionDataset
+from super_gradients.training.utils.detection_utils import DetectionTargetsFormat
+
+
+class DummyDetectionDataset(DetectionDataset):
+    def __init__(self, input_dim, *args, **kwargs):
+        """Dummy Dataset testing subclassing, designed with no annotation that includes class_2."""
+
+        self.image_size = input_dim
+        self.n_samples = 321
+        kwargs['all_classes_list'] = ["class_0", "class_1", "class_2"]
+        kwargs['original_target_format'] = DetectionTargetsFormat.XYXY_LABEL
+        super().__init__(input_dim=input_dim, *args, **kwargs)
+
+    def _setup_data_source(self):
+        return self.n_samples
+
+    def _load_annotation(self, sample_id: int) -> dict:
+        """Every image is made of one target, with label sample_id%len(all_classes_list)
+        """
+        cls_id = sample_id % len(self.all_classes_list)
+        return {"img_path": str(sample_id), "target": np.array([[0, 0, 10, 10, cls_id]]), "resized_img_shape": (self.image_size[0], self.image_size[1]), "seed": sample_id}
+
+    # We overwrite this to fake images
+    def _load_image(self, index: int) -> np.ndarray:
+        np.random.seed(self.annotations[index]["seed"])  # Make sure that the generated random tensor of a given index will be the same over the runs
+        return np.random.random((self.image_size[0], self.image_size[1], 3)) * 255
+
+
+class TestDetectionDatasetCaching(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cache_dir = '/home/data/cache'
+
+    def test_cache_keep_empty(self):
+        """Check that subclassing only keeps annotations of wanted class"""
+
+        datasets = [
+            DummyDetectionDataset(input_dim=(640, 512), ignore_empty_annotations=True, class_inclusion_list=class_inclusion_list,
+                                  cache=False, cache_path=self.cache_dir, data_dir='/home/')
+            for class_inclusion_list in [["class_0", "class_1", "class_2"], ["class_0"], ["class_1"], ["class_2"], ["class_1", "class_2"]]
+        ]
+
+        for first_dataset, second_dataset in zip(datasets[:-1], datasets[1:]):
+            self.assertTrue(np.array_equal(first_dataset.cached_imgs, second_dataset.cached_imgs))
+
+    def test_cache_ignore_empty(self):
+        """Check that subclassing only keeps annotations of wanted class"""
+
+        datasets = [
+            DummyDetectionDataset(input_dim=(640, 512), ignore_empty_annotations=True, class_inclusion_list=class_inclusion_list,
+                                  cache=True, cache_path=self.cache_dir, data_dir='/home/')
+            for class_inclusion_list in [["class_0", "class_1", "class_2"], ["class_0"], ["class_1"], ["class_2"], ["class_1", "class_2"]]
+        ]
+
+        for first_dataset, second_dataset in zip(datasets[:-1], datasets[1:]):
+            self.assertFalse(np.array_equal(first_dataset.cached_imgs, second_dataset.cached_imgs))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adding hash to the name of cached arrays, to make sure that next time we load the cache we will have the expected data.
To do so, the image size and image path are all combined to create the hash, that way if we have exactly the same image path and image size (regardless of the parameters) we will reload the cached array.