### PR TITLE
Fix scale between rescaling batches

### DIFF
--- a/src/super_gradients/training/datasets/datasets_utils.py
+++ b/src/super_gradients/training/datasets/datasets_utils.py
@@ -231,6 +231,7 @@ class MultiscalePrePredictionCallback(AbstractPrePredictionCallback):
         self.rank = None
         self.is_distributed = None
         self.sampled_imres_once = False
+        self.new_input_size = None
 
     def __call__(self, inputs, targets, batch_idx):
         if self.rank is None:
@@ -239,9 +240,9 @@ class MultiscalePrePredictionCallback(AbstractPrePredictionCallback):
             self.is_distributed = get_world_size() > 1
 
         # GENERATE A NEW SIZE AND BROADCAST IT TO THE THE OTHER RANKS SO THEY HAVE THE SAME SCALE
+        input_size = inputs.shape[2:]
         if batch_idx % self.frequency == 0:
             tensor = torch.LongTensor(2).cuda()
-            input_size = inputs.shape[2:]
 
             if self.rank == 0:
                 size_factor = input_size[1] * 1.0 / input_size[0]
@@ -263,12 +264,12 @@ class MultiscalePrePredictionCallback(AbstractPrePredictionCallback):
                 dist.broadcast(tensor, 0)
 
             # Put this to self
-            new_input_size = (tensor[0].item(), tensor[1].item())
+            self.new_input_size = (tensor[0].item(), tensor[1].item())
 
-            scale_y = new_input_size[0] / input_size[0]
-            scale_x = new_input_size[1] / input_size[1]
-            if scale_x != 1 or scale_y != 1:
-                inputs = torch.nn.functional.interpolate(inputs, size=new_input_size, mode="bilinear", align_corners=False)
+        scale_y = self.new_input_size[0] / input_size[0]
+        scale_x = self.new_input_size[1] / input_size[1]
+        if scale_x != 1 or scale_y != 1:
+            inputs = torch.nn.functional.interpolate(inputs, size=self.new_input_size, mode="bilinear", align_corners=False)
         return inputs, targets
 
 

--- a/src/super_gradients/training/datasets/datasets_utils.py
+++ b/src/super_gradients/training/datasets/datasets_utils.py
@@ -263,7 +263,6 @@ class MultiscalePrePredictionCallback(AbstractPrePredictionCallback):
                 dist.barrier()
                 dist.broadcast(tensor, 0)
 
-            # Put this to self
             self.new_input_size = (tensor[0].item(), tensor[1].item())
 
         scale_y = self.new_input_size[0] / input_size[0]

--- a/src/super_gradients/training/datasets/datasets_utils.py
+++ b/src/super_gradients/training/datasets/datasets_utils.py
@@ -262,6 +262,7 @@ class MultiscalePrePredictionCallback(AbstractPrePredictionCallback):
                 dist.barrier()
                 dist.broadcast(tensor, 0)
 
+            # Put this to self
             new_input_size = (tensor[0].item(), tensor[1].item())
 
             scale_y = new_input_size[0] / input_size[0]

--- a/src/super_gradients/training/datasets/datasets_utils.py
+++ b/src/super_gradients/training/datasets/datasets_utils.py
@@ -242,7 +242,7 @@ class MultiscalePrePredictionCallback(AbstractPrePredictionCallback):
         # GENERATE A NEW SIZE AND BROADCAST IT TO THE THE OTHER RANKS SO THEY HAVE THE SAME SCALE
         input_size = inputs.shape[2:]
         if batch_idx % self.frequency == 0:
-            tensor = torch.LongTensor(2).cuda()
+            tensor = torch.LongTensor(2).to(inputs.device)
 
             if self.rank == 0:
                 size_factor = input_size[1] * 1.0 / input_size[0]

--- a/tests/deci_core_unit_test_suite_runner.py
+++ b/tests/deci_core_unit_test_suite_runner.py
@@ -26,6 +26,7 @@ from tests.unit_tests.forward_pass_prep_fn_test import ForwardpassPrepFNTest
 from tests.unit_tests.mask_loss_test import MaskAttentionLossTest
 from tests.unit_tests.detection_sub_sampling_test import TestDetectionDatasetSubsampling
 from tests.unit_tests.detection_sub_classing_test import TestDetectionDatasetSubclassing
+from tests.unit_tests.multi_scaling_test import MultiScaleTest
 
 
 class CoreUnitTestSuiteRunner:
@@ -74,6 +75,7 @@ class CoreUnitTestSuiteRunner:
         self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(IoULossTest))
         self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(TestDetectionDatasetSubsampling))
         self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(TestDetectionDatasetSubclassing))
+        self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(MultiScaleTest))
 
     def _add_modules_to_end_to_end_tests_suite(self):
         """

--- a/tests/unit_tests/multi_scaling_test.py
+++ b/tests/unit_tests/multi_scaling_test.py
@@ -1,0 +1,35 @@
+import unittest
+
+import torch
+from super_gradients.training.datasets.datasets_utils import DetectionMultiscalePrePredictionCallback
+
+
+class MultiScaleTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.size = (1024, 512)
+        self.batch_size = 12
+        self.change_frequency = 10
+        self.multiscale_callback = DetectionMultiscalePrePredictionCallback(change_frequency=self.change_frequency)
+
+    def _create_batch(self):
+        inputs = torch.rand((self.batch_size, 3, self.size[0], self.size[1])) * 255
+        targets = torch.cat([torch.tensor([[[0, 0, 10, 10, 0]]]) for _ in range(self.batch_size)], 0)
+        return inputs, targets
+
+    def test_multiscale_keep_state(self):
+        """Check that the multiscale keeps in memory the new size to use between the size swaps"""
+
+        for i in range(5):
+            post_multiscale_input_shapes = []
+            for j in range(self.change_frequency):
+                inputs, targets = self._create_batch()
+                post_multiscale_input, _ = self.multiscale_callback(inputs, targets, batch_idx=i * self.change_frequency + j)
+                post_multiscale_input_shapes.append(list(post_multiscale_input.shape))
+
+                # The shape should be the same for a given between k * self.change_frequency and (k+1)*self.change_frequency
+                self.assertListEqual(post_multiscale_input_shapes[0], post_multiscale_input_shapes[-1])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
DetectionMultiscalePrePredictionCallback was changed to keep in memory the state of the new rescale size.

Tests done:
- The unit test "MultiScaleTest" was added.
- The recipe "coco2017_yolox" was run without changing any parameter for 1 epoch (it uses DetectionMultiscalePrePredictionCallback)