### PR TITLE
Hydra outputs moved to checkpoints/experiment_name dir

### DIFF
--- a/src/super_gradients/common/environment/env_helpers.py
+++ b/src/super_gradients/common/environment/env_helpers.py
@@ -10,15 +10,16 @@ class TerminalColours:
     """
     Usage: https://stackoverflow.com/questions/287871/how-to-print-colored-text-in-python?page=1&tab=votes#tab-top
     """
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
 
 
 class ColouredTextFormatter:
@@ -27,10 +28,12 @@ class ColouredTextFormatter:
         """
         Prints a text with colour ascii characters.
         """
-        return print(''.join([colour, text, TerminalColours.ENDC]))
+        return print("".join([colour, text, TerminalColours.ENDC]))
 
 
-def get_environ_as_type(environment_variable_name: str, default=None, cast_to_type: type = str) -> object:
+def get_environ_as_type(
+    environment_variable_name: str, default=None, cast_to_type: type = str
+) -> object:
     """
     Tries to get an environment variable and cast it into a requested type.
     :return: cast_to_type object, or None if failed.
@@ -43,7 +46,8 @@ def get_environ_as_type(environment_variable_name: str, default=None, cast_to_ty
         except Exception as e:
             print(e)
             raise ValueError(
-                f'Failed to cast environment variable {environment_variable_name} to type {cast_to_type}: the value {value} is not a valid {cast_to_type}')
+                f"Failed to cast environment variable {environment_variable_name} to type {cast_to_type}: the value {value} is not a valid {cast_to_type}"
+            )
     return
 
 
@@ -53,13 +57,13 @@ def init_trainer():
     by any code running super_gradients. It resolves conflicts between the different tools, packages and environments used
     and prepares the super_gradients environment.
     """
-
+    sys.argv.append(f"pkg_checkpoints_dir={environment_config.PKG_CHECKPOINTS_DIR}")
     parser = argparse.ArgumentParser()
     parser.add_argument("--local_rank", type=int, default=-1)  # used by DDP
     args, _ = parser.parse_known_args()
 
     # remove any flags starting with --local_rank from the argv list
-    to_remove = list(filter(lambda x: x.startswith('--local_rank'), sys.argv))
+    to_remove = list(filter(lambda x: x.startswith("--local_rank"), sys.argv))
     if len(to_remove) > 0:
         for val in to_remove:
             sys.argv.remove(val)
@@ -78,6 +82,7 @@ def multi_process_safe(func):
     If in DDP mode, the function will run only in the main process (local_rank = 0)
     This works only for functions with no return value
     """
+
     def do_nothing(*args, **kwargs):
         pass
 

--- a/src/super_gradients/common/environment/environment_config.py
+++ b/src/super_gradients/common/environment/environment_config.py
@@ -1,6 +1,9 @@
 import logging
 from os import environ
 
+import pkg_resources
+
+PKG_CHECKPOINTS_DIR = pkg_resources.resource_filename("checkpoints", "")
 AWS_ENV_NAME = environ.get("ENVIRONMENT_NAME")
 
 AWS_ENVIRONMENTS = ["development", "staging", "production"]
@@ -13,7 +16,7 @@ if AWS_ENV_NAME not in AWS_ENVIRONMENTS:
             )
         else:
             print(
-                f'Bad AWS environment name: {AWS_ENV_NAME}. Please set an environment variable named ENVIRONMENT_NAME '
+                f"Bad AWS environment name: {AWS_ENV_NAME}. Please set an environment variable named ENVIRONMENT_NAME "
                 f'with one of the values: {",".join(AWS_ENVIRONMENTS)}'
             )
 

--- a/src/super_gradients/recipes/cifar10_resnet.yaml
+++ b/src/super_gradients/recipes/cifar10_resnet.yaml
@@ -11,6 +11,8 @@ defaults:
   - dataset_params: cifar10_dataset_params
   - arch_params: resnet18_cifar_arch_params
   - checkpoint_params: default_checkpoint_params
+  - _self_
+
 
 dataset_interface:
   cifar_10:
@@ -32,4 +34,9 @@ sg_model:
   multi_gpu: Off
 
 architecture: resnet18_cifar
+
+pkg_checkpoints_dir:
+hydra:
+  run:
+    dir: ${pkg_checkpoints_dir}/${sg_model.experiment_name}
 


### PR DESCRIPTION
Change behaviour of Hydra to output logs to user's checkpoints/experiment_name directory
Current behaviour spams output directories with unique timestamps for every run

This solves the bug where datasets such as cifar10, mnist, etc. were downloaded and extracted from scratch in each run.
In addition, this allows for easy loading of trained model, since now checkpoints are stored together with the YAML config that created them. A simple script can rebuild the model and load the weighs to it.

- flake8 cleanup
- environment_config.py: line 6 added package checkpoints dir as environment variable
- env_helpers.py: line 60 added argument for Hydra output dir init
- checkpoint_utils: line 51 used global PKG_CHECKPOINTS_DIR since it already exists

I recommend removing support for "external_checkpoint_path"; users can create symbolic links instead for now