### PR TITLE
Fix coco recipes

### DIFF
--- a/src/super_gradients/recipes/coco2017_ssd_lite_mobilenet_v2.yaml
+++ b/src/super_gradients/recipes/coco2017_ssd_lite_mobilenet_v2.yaml
@@ -32,7 +32,7 @@ architecture: ssd_lite_mobilenet_v2
 
 data_loader_num_workers: 8
 model_checkpoints_location: local
-experiment_suffix: res${dataset_params.train_input_dim}
+experiment_suffix: res${dataset_params.train_image_size}
 experiment_name: ${architecture}_coco_${experiment_suffix}
 
 sg_model:

--- a/src/super_gradients/recipes/coco2017_yolox.yaml
+++ b/src/super_gradients/recipes/coco2017_yolox.yaml
@@ -34,7 +34,8 @@ architecture: yolox_s
 
 multi_gpu: DDP
 
-experiment_name: ${architecture}_coco2017_${dataset_params.train_input_dim}
+experiment_suffix: res${dataset_params.train_image_size}
+experiment_name: ${architecture}_coco2017_${experiment_suffix}
 
 ckpt_root_dir:
 sg_model:

--- a/src/super_gradients/recipes/dataset_params/coco_detection_ssd_lite_mobilenet_v2_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/coco_detection_ssd_lite_mobilenet_v2_dataset_params.yaml
@@ -1,7 +1,7 @@
 defaults:
   - coco_detection_yolox_dataset_params
 
-cache_dir_path: # path to a directory that will be used for caching (with numpy.memmap).
+cache_dir: # path to a directory that will be used for caching (with numpy.memmap).
 cache_train_images: False
 cache_val_images: False
 
@@ -58,6 +58,8 @@ train_collate_fn: # collate function for trainset
   _target_: super_gradients.training.utils.detection_utils.DetectionCollateFN
 
 class_inclusion_list: # If not None,every class not included will be ignored.
+train_max_num_samples: # If not None, only specified number of samples will be loaded in train dataset
+val_max_num_samples:   # If not None, only specified number of samples will be loaded in test dataset
 with_crowd: False # whether to return "crowd" labels in validation
 
 _convert_: all

--- a/src/super_gradients/recipes/dataset_params/coco_detection_yolox_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/coco_detection_yolox_dataset_params.yaml
@@ -4,16 +4,22 @@ val_subdir: images/val2017 # sub directory path of data_dir containing the valid
 train_json_file: instances_train2017.json # path to coco train json file, data_dir/annotations/train_json_file.
 val_json_file: instances_val2017.json # path to coco validation json file, data_dir/annotations/val_json_file.
 
-cache_dir_path: # path to a directory that will be used for caching (with numpy.memmap).
+cache_dir: # path to a directory that will be used for caching (with numpy.memmap).
 cache_train_images: False
 cache_val_images: False
 
-
 batch_size: 16 # batch size for trainset
 val_batch_size: 64 # batch size for valset
-train_input_dim: [640, 640]
-val_input_dim: [640, 640]
+train_image_size: 640
+val_image_size: 640
+train_input_dim:
+  - ${dataset_params.train_image_size}
+  - ${dataset_params.train_image_size}
+val_input_dim:
+  - ${dataset_params.val_image_size}
+  - ${dataset_params.val_image_size}
 
+filter_box_candidates: False
 targets_format:
   _target_: super_gradients.training.utils.detection_utils.DetectionTargetsFormat # targets format
   value: LABEL_CXCYWH
@@ -64,6 +70,8 @@ train_collate_fn: # collate function for trainset
   _target_: super_gradients.training.utils.detection_utils.DetectionCollateFN
 
 class_inclusion_list: # If not None,every class not included will be ignored.
+train_max_num_samples: # If not None, only specified number of samples will be loaded in train dataset
+val_max_num_samples:   # If not None, only specified number of samples will be loaded in test dataset
 with_crowd: False     # Whether to return "crowd" labels in validation
 
 _convert_: all


### PR DESCRIPTION
- Fix the experiment name to not include a whitespace
- Add default values to all parameters (class_inclusion_list, train_max_num_samples, ...)
- 
coco_detection_ssd_lite_mobilenet_v2_dataset_params and coco2017_yolox were tested