### PR TITLE
Feature/hydra output dir

### DIFF
--- a/src/super_gradients/common/environment/env_helpers.py
+++ b/src/super_gradients/common/environment/env_helpers.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import sys
 from functools import wraps
+from omegaconf import OmegaConf
 
 from super_gradients.common.environment import environment_config
 
@@ -51,13 +52,23 @@ def get_environ_as_type(
     return
 
 
+def hydra_output_dir_resolver(ckpt_root_dir, experiment_name):
+    if ckpt_root_dir is None:
+        output_dir_path = (
+            environment_config.PKG_CHECKPOINTS_DIR + os.path.sep + experiment_name
+        )
+    else:
+        output_dir_path = ckpt_root_dir + os.path.sep + experiment_name
+    return output_dir_path
+
+
 def init_trainer():
     """
     a function to initialize the super_gradients environment. This function should be the first thing to be called
     by any code running super_gradients. It resolves conflicts between the different tools, packages and environments used
     and prepares the super_gradients environment.
     """
-    sys.argv.append(f"pkg_checkpoints_dir={environment_config.PKG_CHECKPOINTS_DIR}")
+    OmegaConf.register_new_resolver("hydra_output_dir", hydra_output_dir_resolver)
     parser = argparse.ArgumentParser()
     parser.add_argument("--local_rank", type=int, default=-1)  # used by DDP
     args, _ = parser.parse_known_args()

--- a/src/super_gradients/common/environment/env_helpers.py
+++ b/src/super_gradients/common/environment/env_helpers.py
@@ -10,15 +10,16 @@ class TerminalColours:
     """
     Usage: https://stackoverflow.com/questions/287871/how-to-print-colored-text-in-python?page=1&tab=votes#tab-top
     """
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
 
 
 class ColouredTextFormatter:
@@ -27,10 +28,12 @@ class ColouredTextFormatter:
         """
         Prints a text with colour ascii characters.
         """
-        return print(''.join([colour, text, TerminalColours.ENDC]))
+        return print("".join([colour, text, TerminalColours.ENDC]))
 
 
-def get_environ_as_type(environment_variable_name: str, default=None, cast_to_type: type = str) -> object:
+def get_environ_as_type(
+    environment_variable_name: str, default=None, cast_to_type: type = str
+) -> object:
     """
     Tries to get an environment variable and cast it into a requested type.
     :return: cast_to_type object, or None if failed.
@@ -43,7 +46,8 @@ def get_environ_as_type(environment_variable_name: str, default=None, cast_to_ty
         except Exception as e:
             print(e)
             raise ValueError(
-                f'Failed to cast environment variable {environment_variable_name} to type {cast_to_type}: the value {value} is not a valid {cast_to_type}')
+                f"Failed to cast environment variable {environment_variable_name} to type {cast_to_type}: the value {value} is not a valid {cast_to_type}"
+            )
     return
 
 
@@ -53,13 +57,13 @@ def init_trainer():
     by any code running super_gradients. It resolves conflicts between the different tools, packages and environments used
     and prepares the super_gradients environment.
     """
-
+    sys.argv.append(f"pkg_checkpoints_dir={environment_config.PKG_CHECKPOINTS_DIR}")
     parser = argparse.ArgumentParser()
     parser.add_argument("--local_rank", type=int, default=-1)  # used by DDP
     args, _ = parser.parse_known_args()
 
     # remove any flags starting with --local_rank from the argv list
-    to_remove = list(filter(lambda x: x.startswith('--local_rank'), sys.argv))
+    to_remove = list(filter(lambda x: x.startswith("--local_rank"), sys.argv))
     if len(to_remove) > 0:
         for val in to_remove:
             sys.argv.remove(val)
@@ -78,6 +82,7 @@ def multi_process_safe(func):
     If in DDP mode, the function will run only in the main process (local_rank = 0)
     This works only for functions with no return value
     """
+
     def do_nothing(*args, **kwargs):
         pass
 

--- a/src/super_gradients/common/environment/env_helpers.py
+++ b/src/super_gradients/common/environment/env_helpers.py
@@ -68,7 +68,7 @@ def init_trainer():
     by any code running super_gradients. It resolves conflicts between the different tools, packages and environments used
     and prepares the super_gradients environment.
     """
-    OmegaConf.register_new_resolver("hydra_output_dir", hydra_output_dir_resolver)
+    OmegaConf.register_new_resolver("hydra_output_dir", hydra_output_dir_resolver, replace=True)
     parser = argparse.ArgumentParser()
     parser.add_argument("--local_rank", type=int, default=-1)  # used by DDP
     args, _ = parser.parse_known_args()

--- a/src/super_gradients/common/environment/environment_config.py
+++ b/src/super_gradients/common/environment/environment_config.py
@@ -1,6 +1,9 @@
 import logging
 from os import environ
 
+import pkg_resources
+
+PKG_CHECKPOINTS_DIR = pkg_resources.resource_filename("checkpoints", "")
 AWS_ENV_NAME = environ.get("ENVIRONMENT_NAME")
 
 AWS_ENVIRONMENTS = ["development", "staging", "production"]
@@ -13,7 +16,7 @@ if AWS_ENV_NAME not in AWS_ENVIRONMENTS:
             )
         else:
             print(
-                f'Bad AWS environment name: {AWS_ENV_NAME}. Please set an environment variable named ENVIRONMENT_NAME '
+                f"Bad AWS environment name: {AWS_ENV_NAME}. Please set an environment variable named ENVIRONMENT_NAME "
                 f'with one of the values: {",".join(AWS_ENVIRONMENTS)}'
             )
 

--- a/src/super_gradients/recipes/cifar10_resnet.yaml
+++ b/src/super_gradients/recipes/cifar10_resnet.yaml
@@ -35,8 +35,7 @@ sg_model:
 
 architecture: resnet18_cifar
 
-pkg_checkpoints_dir:
 hydra:
   run:
-    dir: ${pkg_checkpoints_dir}/${sg_model.experiment_name}
+    dir: ${hydra_output_dir:${ckpt_root_dir}, ${experiment_name}}
 

--- a/src/super_gradients/recipes/cifar10_resnet.yaml
+++ b/src/super_gradients/recipes/cifar10_resnet.yaml
@@ -11,6 +11,8 @@ defaults:
   - dataset_params: cifar10_dataset_params
   - arch_params: resnet18_cifar_arch_params
   - checkpoint_params: default_checkpoint_params
+  - _self_
+
 
 dataset_interface:
   cifar_10:
@@ -32,4 +34,9 @@ sg_model:
   multi_gpu: Off
 
 architecture: resnet18_cifar
+
+pkg_checkpoints_dir:
+hydra:
+  run:
+    dir: ${pkg_checkpoints_dir}/${sg_model.experiment_name}
 

--- a/src/super_gradients/training/utils/checkpoint_utils.py
+++ b/src/super_gradients/training/utils/checkpoint_utils.py
@@ -4,28 +4,18 @@ import tempfile
 import pkg_resources
 import torch
 
-from super_gradients.common import (
-    explicit_params_validation,
-    ADNNModelRepositoryDataInterfaces,
-)
+from super_gradients.common import explicit_params_validation, ADNNModelRepositoryDataInterfaces
 from super_gradients.training.pretrained_models import MODEL_URLS
 
 try:
     from torch.hub import download_url_to_file, load_state_dict_from_url
 except (ModuleNotFoundError, ImportError, NameError):
     from torch.hub import _download_url_to_file as download_url_to_file
-from super_gradients.common.environment import environment_config
 
 
-def get_ckpt_local_path(
-    source_ckpt_folder_name: str,
-    experiment_name: str,
-    ckpt_name: str,
-    model_checkpoints_location: str,
-    external_checkpoint_path: str,
-    overwrite_local_checkpoint: bool,
-    load_weights_only: bool,
-):
+def get_ckpt_local_path(source_ckpt_folder_name: str, experiment_name: str, ckpt_name: str,
+                        model_checkpoints_location: str, external_checkpoint_path: str,
+                        overwrite_local_checkpoint: bool, load_weights_only: bool):
     """
     Gets the local path to the checkpoint file, which will be:
         - By default: YOUR_REPO_ROOT/super_gradients/checkpoints/experiment_name.
@@ -45,38 +35,24 @@ def get_ckpt_local_path(
     @return:
     """
     source_ckpt_folder_name = source_ckpt_folder_name or experiment_name
-    if model_checkpoints_location == "local":
-        ckpt_local_path = (
-            external_checkpoint_path
-            or environment_config.PKG_CHECKPOINTS_DIR
-            + os.path.sep
-            + source_ckpt_folder_name
-            + os.path.sep
-            + ckpt_name
-        )
+    if model_checkpoints_location == 'local':
+        ckpt_local_path = external_checkpoint_path or pkg_resources.resource_filename('checkpoints',
+                                                                                      source_ckpt_folder_name + os.path.sep + ckpt_name)
 
     # COPY THE DATA FROM 'S3'/'URL' INTO A LOCAL DIRECTORY
-    elif (
-        model_checkpoints_location.startswith("s3")
-        or model_checkpoints_location == "url"
-    ):
+    elif model_checkpoints_location.startswith('s3') or model_checkpoints_location == 'url':
         # COPY REMOTE DATA TO A LOCAL DIRECTORY AND GET THAT DIRECTORYs NAME
-        ckpt_local_path = copy_ckpt_to_local_folder(
-            local_ckpt_destination_dir=experiment_name,
-            ckpt_filename=ckpt_name,
-            remote_ckpt_source_dir=source_ckpt_folder_name,
-            path_src=model_checkpoints_location,
-            overwrite_local_ckpt=overwrite_local_checkpoint,
-            load_weights_only=load_weights_only,
-        )
+        ckpt_local_path = copy_ckpt_to_local_folder(local_ckpt_destination_dir=experiment_name,
+                                                    ckpt_filename=ckpt_name,
+                                                    remote_ckpt_source_dir=source_ckpt_folder_name,
+                                                    path_src=model_checkpoints_location,
+                                                    overwrite_local_ckpt=overwrite_local_checkpoint,
+                                                    load_weights_only=load_weights_only)
 
     else:
         # ERROR IN USER CODE FLOW - THIS WILL EVENTUALLY RAISE AN EXCEPTION
         raise NotImplementedError(
-            "model_checkpoints_data_source: "
-            + str(model_checkpoints_location)
-            + "not supported"
-        )
+            'model_checkpoints_data_source: ' + str(model_checkpoints_location) + 'not supported')
 
     return ckpt_local_path
 
@@ -91,26 +67,19 @@ def adaptive_load_state_dict(net: torch.nn.Module, state_dict: dict, strict: str
     @return:
     """
     try:
-        net.load_state_dict(state_dict["net"], strict=strict)
+        net.load_state_dict(state_dict['net'], strict=strict)
     except (RuntimeError, ValueError, KeyError) as ex:
-        if strict == "no_key_matching":
-            adapted_state_dict = adapt_state_dict_to_fit_model_layer_names(
-                net.state_dict(), state_dict
-            )
-            net.load_state_dict(adapted_state_dict["net"], strict=True)
+        if strict == 'no_key_matching':
+            adapted_state_dict = adapt_state_dict_to_fit_model_layer_names(net.state_dict(), state_dict)
+            net.load_state_dict(adapted_state_dict['net'], strict=True)
         else:
             raise_informative_runtime_error(net.state_dict(), state_dict, ex)
 
 
-@explicit_params_validation(validation_type="None")
-def copy_ckpt_to_local_folder(
-    local_ckpt_destination_dir: str,
-    ckpt_filename: str,
-    remote_ckpt_source_dir: str = None,
-    path_src: str = "local",
-    overwrite_local_ckpt: bool = False,
-    load_weights_only: bool = False,
-):
+@explicit_params_validation(validation_type='None')
+def copy_ckpt_to_local_folder(local_ckpt_destination_dir: str, ckpt_filename: str, remote_ckpt_source_dir: str = None,
+                              path_src: str = 'local', overwrite_local_ckpt: bool = False,
+                              load_weights_only: bool = False):
     """
     Copy the checkpoint from any supported source to a local destination path
         :param local_ckpt_destination_dir:  destination where the checkpoint will be saved to
@@ -124,61 +93,42 @@ def copy_ckpt_to_local_folder(
     ckpt_file_full_local_path = None
 
     # IF NOT DEFINED - IT IS SET TO THE TARGET's FOLDER NAME
-    remote_ckpt_source_dir = (
-        local_ckpt_destination_dir
-        if remote_ckpt_source_dir is None
-        else remote_ckpt_source_dir
-    )
+    remote_ckpt_source_dir = local_ckpt_destination_dir if remote_ckpt_source_dir is None else remote_ckpt_source_dir
 
     if not overwrite_local_ckpt:
         # CREATE A TEMP FOLDER TO SAVE THE CHECKPOINT TO
         download_ckpt_destination_dir = tempfile.gettempdir()
-        print(
-            "PLEASE NOTICE - YOU ARE IMPORTING A REMOTE CHECKPOINT WITH overwrite_local_checkpoint = False "
-            "-> IT WILL BE REDIRECTED TO A TEMP FOLDER AND DELETED ON MACHINE RESTART"
-        )
+        print('PLEASE NOTICE - YOU ARE IMPORTING A REMOTE CHECKPOINT WITH overwrite_local_checkpoint = False '
+              '-> IT WILL BE REDIRECTED TO A TEMP FOLDER AND DELETED ON MACHINE RESTART')
     else:
         # SAVE THE CHECKPOINT TO MODEL's FOLDER
-        download_ckpt_destination_dir = pkg_resources.resource_filename(
-            "checkpoints", local_ckpt_destination_dir
-        )
+        download_ckpt_destination_dir = pkg_resources.resource_filename('checkpoints', local_ckpt_destination_dir)
 
-    if path_src.startswith("s3"):
-        model_checkpoints_data_interface = ADNNModelRepositoryDataInterfaces(
-            data_connection_location=path_src
-        )
+    if path_src.startswith('s3'):
+        model_checkpoints_data_interface = ADNNModelRepositoryDataInterfaces(data_connection_location=path_src)
         # DOWNLOAD THE FILE FROM S3 TO THE DESTINATION FOLDER
-        ckpt_file_full_local_path = (
-            model_checkpoints_data_interface.load_remote_checkpoints_file(
-                ckpt_source_remote_dir=remote_ckpt_source_dir,
-                ckpt_destination_local_dir=download_ckpt_destination_dir,
-                ckpt_file_name=ckpt_filename,
-                overwrite_local_checkpoints_file=overwrite_local_ckpt,
-            )
-        )
+        ckpt_file_full_local_path = model_checkpoints_data_interface.load_remote_checkpoints_file(
+            ckpt_source_remote_dir=remote_ckpt_source_dir,
+            ckpt_destination_local_dir=download_ckpt_destination_dir,
+            ckpt_file_name=ckpt_filename,
+            overwrite_local_checkpoints_file=overwrite_local_ckpt)
 
         if not load_weights_only:
             # COPY LOG FILES FROM THE REMOTE DIRECTORY TO THE LOCAL ONE ONLY IF LOADING THE CURRENT MODELs CKPT
-            model_checkpoints_data_interface.load_all_remote_log_files(
-                model_name=remote_ckpt_source_dir,
-                model_checkpoint_local_dir=download_ckpt_destination_dir,
-            )
+            model_checkpoints_data_interface.load_all_remote_log_files(model_name=remote_ckpt_source_dir,
+                                                                       model_checkpoint_local_dir=download_ckpt_destination_dir)
 
-    if path_src == "url":
-        ckpt_file_full_local_path = (
-            download_ckpt_destination_dir + os.path.sep + ckpt_filename
-        )
+    if path_src == 'url':
+        ckpt_file_full_local_path = download_ckpt_destination_dir + os.path.sep + ckpt_filename
         # DOWNLOAD THE FILE FROM URL TO THE DESTINATION FOLDER
-        download_url_to_file(
-            remote_ckpt_source_dir, ckpt_file_full_local_path, progress=True
-        )
+        download_url_to_file(remote_ckpt_source_dir, ckpt_file_full_local_path, progress=True)
 
     return ckpt_file_full_local_path
 
 
 def read_ckpt_state_dict(ckpt_path: str, device="cpu"):
     if not os.path.exists(ckpt_path):
-        raise ValueError("Incorrect Checkpoint path")
+        raise ValueError('Incorrect Checkpoint path')
 
     if device == "cuda":
         state_dict = torch.load(ckpt_path)
@@ -188,12 +138,8 @@ def read_ckpt_state_dict(ckpt_path: str, device="cpu"):
     return state_dict
 
 
-def adapt_state_dict_to_fit_model_layer_names(
-    model_state_dict: dict,
-    source_ckpt: dict,
-    exclude: list = [],
-    solver: callable = None,
-):
+def adapt_state_dict_to_fit_model_layer_names(model_state_dict: dict, source_ckpt: dict,
+                                              exclude: list = [], solver: callable = None):
     """
     Given a model state dict and source checkpoints, the method tries to correct the keys in the model_state_dict to fit
     the ckpt in order to properly load the weights into the model. If unsuccessful - returns None
@@ -204,24 +150,18 @@ def adapt_state_dict_to_fit_model_layer_names(
                                         that returns a desired weight for ckpt_val.
         :return: renamed checkpoint dict (if possible)
     """
-    if "net" in source_ckpt.keys():
-        source_ckpt = source_ckpt["net"]
-    model_state_dict_excluded = {
-        k: v for k, v in model_state_dict.items() if not any(x in k for x in exclude)
-    }
+    if 'net' in source_ckpt.keys():
+        source_ckpt = source_ckpt['net']
+    model_state_dict_excluded = {k: v for k, v in model_state_dict.items() if not any(x in k for x in exclude)}
     new_ckpt_dict = {}
-    for (ckpt_key, ckpt_val), (model_key, model_val) in zip(
-        source_ckpt.items(), model_state_dict_excluded.items()
-    ):
+    for (ckpt_key, ckpt_val), (model_key, model_val) in zip(source_ckpt.items(), model_state_dict_excluded.items()):
         if solver is not None:
             ckpt_val = solver(ckpt_key, ckpt_val, model_key, model_val)
         if ckpt_val.shape != model_val.shape:
-            raise ValueError(
-                f"ckpt layer {ckpt_key} with shape {ckpt_val.shape} does not match {model_key}"
-                f" with shape {model_val.shape} in the model"
-            )
+            raise ValueError(f'ckpt layer {ckpt_key} with shape {ckpt_val.shape} does not match {model_key}'
+                             f' with shape {model_val.shape} in the model')
         new_ckpt_dict[model_key] = ckpt_val
-    return {"net": new_ckpt_dict}
+    return {'net': new_ckpt_dict}
 
 
 def raise_informative_runtime_error(state_dict, checkpoint, exception_msg):
@@ -230,29 +170,19 @@ def raise_informative_runtime_error(state_dict, checkpoint, exception_msg):
     and enhances the exception_msg if loading the checkpoint_dict via the conversion method is possible
     """
     try:
-        new_ckpt_dict = adapt_state_dict_to_fit_model_layer_names(
-            state_dict, checkpoint
-        )
-        temp_file = tempfile.NamedTemporaryFile().name + ".pt"
+        new_ckpt_dict = adapt_state_dict_to_fit_model_layer_names(state_dict, checkpoint)
+        temp_file = tempfile.NamedTemporaryFile().name + '.pt'
         torch.save(new_ckpt_dict, temp_file)
-        exception_msg = (
-            f"\n{'=' * 200}\n{str(exception_msg)} \nconvert ckpt via the utils.adapt_state_dict_to_fit_"
-            f"model_layer_names method\na converted checkpoint file was saved in the path {temp_file}\n{'=' * 200}"
-        )
+        exception_msg = f"\n{'=' * 200}\n{str(exception_msg)} \nconvert ckpt via the utils.adapt_state_dict_to_fit_" \
+                        f"model_layer_names method\na converted checkpoint file was saved in the path {temp_file}\n{'=' * 200}"
     except ValueError as ex:  # IN CASE adapt_state_dict_to_fit_model_layer_names WAS UNSUCCESSFUL
         exception_msg = f"\n{'=' * 200} \nThe checkpoint and model shapes do no fit, e.g.: {ex}\n{'=' * 200}"
     finally:
         raise RuntimeError(exception_msg)
 
 
-def load_checkpoint_to_model(
-    ckpt_local_path: str,
-    load_backbone: bool,
-    net: torch.nn.Module,
-    strict: str,
-    load_weights_only: bool,
-    load_ema_as_net: bool = False,
-):
+def load_checkpoint_to_model(ckpt_local_path: str, load_backbone: bool, net: torch.nn.Module, strict: str,
+                             load_weights_only: bool, load_ema_as_net: bool = False):
     """
     Loads the state dict in ckpt_local_path to net and returns the checkpoint's state dict.
 
@@ -265,24 +195,20 @@ def load_checkpoint_to_model(
     @return:
     """
     if ckpt_local_path is None or not os.path.exists(ckpt_local_path):
-        error_msg = "Error - loading Model Checkpoint: Path {} does not exist".format(
-            ckpt_local_path
-        )
+        error_msg = 'Error - loading Model Checkpoint: Path {} does not exist'.format(ckpt_local_path)
         raise RuntimeError(error_msg)
 
-    if load_backbone and not hasattr(net.module, "backbone"):
+    if load_backbone and not hasattr(net.module, 'backbone'):
         raise ValueError("No backbone attribute in net - Can't load backbone weights")
 
     # LOAD THE LOCAL CHECKPOINT PATH INTO A state_dict OBJECT
     checkpoint = read_ckpt_state_dict(ckpt_path=ckpt_local_path)
 
     if load_ema_as_net:
-        if "ema_net" not in checkpoint.keys():
-            raise ValueError(
-                "Can't load ema network- no EMA network stored in checkpoint file"
-            )
+        if 'ema_net' not in checkpoint.keys():
+            raise ValueError("Can't load ema network- no EMA network stored in checkpoint file")
         else:
-            checkpoint["net"] = checkpoint["ema_net"]
+            checkpoint['net'] = checkpoint['ema_net']
 
     # LOAD THE CHECKPOINTS WEIGHTS TO THE MODEL
     if load_backbone:
@@ -292,7 +218,7 @@ def load_checkpoint_to_model(
 
     if load_weights_only or load_backbone:
         # DISCARD ALL THE DATA STORED IN CHECKPOINT OTHER THAN THE WEIGHTS
-        [checkpoint.pop(key) for key in list(checkpoint.keys()) if key != "net"]
+        [checkpoint.pop(key) for key in list(checkpoint.keys()) if key != 'net']
 
     return checkpoint
 
@@ -314,11 +240,8 @@ def _yolox_ckpt_solver(ckpt_key, ckpt_val, model_key, model_val):
     Helper method for reshaping old pretrained checkpoint's focus weights to 6x6 conv weights.
     """
 
-    if (
-        ckpt_val.shape != model_val.shape
-        and ckpt_key == "module._backbone._modules_list.0.conv.conv.weight"
-        and model_key == "_backbone._modules_list.0.conv.weight"
-    ):
+    if ckpt_val.shape != model_val.shape and ckpt_key == 'module._backbone._modules_list.0.conv.conv.weight' and \
+            model_key == '_backbone._modules_list.0.conv.weight':
         model_val.data[:, :, ::2, ::2] = ckpt_val.data[:, :3]
         model_val.data[:, :, 1::2, ::2] = ckpt_val.data[:, 3:6]
         model_val.data[:, :, ::2, 1::2] = ckpt_val.data[:, 6:9]
@@ -330,9 +253,7 @@ def _yolox_ckpt_solver(ckpt_key, ckpt_val, model_key, model_val):
     return replacement
 
 
-def load_pretrained_weights(
-    model: torch.nn.Module, architecture: str, pretrained_weights: str
-):
+def load_pretrained_weights(model: torch.nn.Module, architecture: str, pretrained_weights: str):
     """
     Loads pretrained weights from the MODEL_URLS dictionary to model
     @param architecture: name of the model's architecture
@@ -340,26 +261,19 @@ def load_pretrained_weights(
     @param pretrained_weights: name for the pretrianed weights (i.e imagenet)
     @return: None
     """
-    model_url_key = architecture + "_" + str(pretrained_weights)
+    model_url_key = architecture + '_' + str(pretrained_weights)
     if model_url_key not in MODEL_URLS.keys():
         raise MissingPretrainedWeightsException(model_url_key)
 
     url = MODEL_URLS[model_url_key]
-    unique_filename = (
-        url.split("https://deci-pretrained-models.s3.amazonaws.com/")[1]
-        .replace("/", "_")
-        .replace(" ", "_")
-    )
-    map_location = torch.device("cpu") if not torch.cuda.is_available() else None
-    pretrained_state_dict = load_state_dict_from_url(
-        url=url, map_location=map_location, file_name=unique_filename
-    )
-    if "ema_net" in pretrained_state_dict.keys():
-        pretrained_state_dict["net"] = pretrained_state_dict["ema_net"]
+    unique_filename = url.split("https://deci-pretrained-models.s3.amazonaws.com/")[1].replace('/', '_').replace(' ',
+                                                                                                                 '_')
+    map_location = torch.device('cpu') if not torch.cuda.is_available() else None
+    pretrained_state_dict = load_state_dict_from_url(url=url, map_location=map_location, file_name=unique_filename)
+    if 'ema_net' in pretrained_state_dict.keys():
+        pretrained_state_dict['net'] = pretrained_state_dict['ema_net']
     solver = _yolox_ckpt_solver if "yolox" in architecture else None
-    adapted_pretrained_state_dict = adapt_state_dict_to_fit_model_layer_names(
-        model_state_dict=model.state_dict(),
-        source_ckpt=pretrained_state_dict,
-        solver=solver,
-    )
-    model.load_state_dict(adapted_pretrained_state_dict["net"], strict=False)
+    adapted_pretrained_state_dict = adapt_state_dict_to_fit_model_layer_names(model_state_dict=model.state_dict(),
+                                                                              source_ckpt=pretrained_state_dict,
+                                                                              solver=solver)
+    model.load_state_dict(adapted_pretrained_state_dict['net'], strict=False)


### PR DESCRIPTION
Change behaviour of Hydra to output logs to user's checkpoints/experiment_name directory
Current behaviour spams output directories with unique timestamps for every run

This solves the bug where datasets such as cifar10, mnist, etc. were downloaded and extracted from scratch in each run.
In addition, this allows for easy loading of trained model, since now checkpoints are stored together with the YAML config that created them. A simple script can rebuild the model and load the weighs to it.

