### PR TITLE
teacher adpator freeze + map location cpu for all pretrained models

### DIFF
--- a/src/super_gradients/recipes/checkpoint_params/default_checkpoint_params.yaml
+++ b/src/super_gradients/recipes/checkpoint_params/default_checkpoint_params.yaml
@@ -1,7 +1,6 @@
 checkpoint_path:
 load_checkpoint: False # whether to load checkpoint
 load_backbone: False # whether to load only backbone part of checkpoint
-external_checkpoint_path: # checkpoint path that is not located in super_gradients/checkpoints
 source_ckpt_folder_name: # dirname for checkpoint loading
 strict_load: # key matching strictness for loading checkpoint's weights
   _target_: super_gradients.training.sg_trainer.StrictLoad

--- a/src/super_gradients/recipes/imagenet_resnet50_kd.yaml
+++ b/src/super_gradients/recipes/imagenet_resnet50_kd.yaml
@@ -52,6 +52,9 @@ teacher_checkpoint_params:
     value: True
   pretrained_weights: imagenet
 
+checkpoint_params:
+  teacher_pretrained_weights: imagenet
+
 student_checkpoint_params:
   load_backbone: False # whether to load only backbone part of checkpoint
   checkpoint_path: # checkpoint path that is not located in super_gradients/checkpoints

--- a/src/super_gradients/training/models/kd_modules/kd_module.py
+++ b/src/super_gradients/training/models/kd_modules/kd_module.py
@@ -42,6 +42,11 @@ class KDModule(SgModule):
         for p in self.teacher.parameters():
             p.requires_grad = False
 
+        if self.teacher_input_adapter is not None:
+            for p in self.teacher_input_adapter.parameters():
+                p.requires_grad = False
+            self.teacher_input_adapter.eval()
+
     def train(self, mode=True):
         self.student.train(mode)
         if not self.run_teacher_on_eval:

--- a/src/super_gradients/training/utils/checkpoint_utils.py
+++ b/src/super_gradients/training/utils/checkpoint_utils.py
@@ -263,7 +263,7 @@ def load_pretrained_weights(model: torch.nn.Module, architecture: str, pretraine
 
     url = MODEL_URLS[model_url_key]
     unique_filename = url.split("https://deci-pretrained-models.s3.amazonaws.com/")[1].replace('/', '_').replace(' ', '_')
-    map_location = torch.device('cpu') if not torch.cuda.is_available() else None
+    map_location = torch.device('cpu')
     pretrained_state_dict = load_state_dict_from_url(url=url, map_location=map_location, file_name=unique_filename)
     if 'ema_net' in pretrained_state_dict.keys():
         pretrained_state_dict['net'] = pretrained_state_dict['ema_net']


### PR DESCRIPTION
Imagenet resent50 KD recipe was broken because of changes in https://github.com/Deci-AI/super-gradients/pull/319 .
(Input adaptor's parameters had require_grad=True which led to CUDA OOM).
Additionally map location=None in load_pretrained_weights caused to having extra GPU memory allocated in rank:0 when training in DDP. I removed it since the net is moved to the proper device in Trainer anyways.