### PR TITLE
fix: Plot detection in RGB

### DIFF
--- a/src/super_gradients/training/datasets/detection_datasets/detection_dataset.py
+++ b/src/super_gradients/training/datasets/detection_datasets/detection_dataset.py
@@ -431,7 +431,7 @@ class DetectionDataset(Dataset):
 
                 # shape = [n_box x 4] (We remove padded boxes, which corresponds to boxes with only 0)
                 boxes = boxes[(boxes != 0).any(axis=1)]
-                plt.subplot(n_subplot, n_subplot, img_i + 1).imshow(image)
+                plt.subplot(n_subplot, n_subplot, img_i + 1).imshow(image[:, :, ::-1])
                 plt.plot(boxes[:, [0, 2, 2, 0, 0]].T, boxes[:, [1, 1, 3, 3, 1]].T, '.-')
                 plt.axis('off')
             fig.tight_layout()


### PR DESCRIPTION
The images are loaded in detection dataset in BGR, so I think it's safe to assume whatever is plotted in the same class is always BGR and should be converted to RGB before displaying.
R.n. we are plotting creepy blue pics