### PR TITLE
Fixes for segmentation notebooks

### DIFF
--- a/src/super_gradients/recipes/dataset_params/supervisely_persons_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/supervisely_persons_dataset_params.yaml
@@ -4,20 +4,17 @@ train_dataset_params:
   cache_labels: False
   cache_images: False
   transforms:
-    - ResizeSeg:
-        h: 480
-        w: 320
+    - RandomRescaleSeg:
+        scales: [ 0.25, 1. ]
     - ColorJitterSeg:
         brightness: 0.5
         contrast: 0.5
         saturation: 0.5
     - RandomFlipSeg:
         prob: 0.5
-    - RandomRescaleSeg:
-        scales: [ 0.25, 1. ]
     - PadShortToCropSizeSeg:
         crop_size: [ 320, 480 ]
-        fill_mask: 19
+        fill_mask: 0
     - CropImageAndMaskSeg:
         crop_size: [ 320, 480 ]
         mode: random

--- a/src/super_gradients/training/models/segmentation_models/ppliteseg.py
+++ b/src/super_gradients/training/models/segmentation_models/ppliteseg.py
@@ -345,6 +345,11 @@ class PPLiteSegBase(SegmentationModule):
         if isinstance(self.encoder.context_module, SPPM):
             self.encoder.context_module.prep_model_for_conversion(input_size=input_size, stride_ratio=stride_ratio)
 
+    def replace_head(self, new_num_classes: int, **kwargs):
+        for module in self.modules():
+            if isinstance(module, SegmentationHead):
+                module.replace_num_classes(new_num_classes)
+
 
 class PPLiteSegB(PPLiteSegBase):
     def __init__(self, arch_params: HpmStruct):

--- a/src/super_gradients/training/models/segmentation_models/stdc.py
+++ b/src/super_gradients/training/models/segmentation_models/stdc.py
@@ -381,6 +381,14 @@ class SegmentationHead(nn.Module):
     def forward(self, x):
         return self.seg_head(x)
 
+    def replace_num_classes(self, num_classes: int):
+        """
+        This method replace the last Conv Classification layer to output a different number of classes.
+        Note that the weights of the new layers are random initiated.
+        """
+        old_cls_conv = self.seg_head[-1]
+        self.seg_head[-1] = nn.Conv2d(old_cls_conv.in_channels, num_classes, kernel_size=1, bias=False)
+
 
 class STDCSegmentationBase(SgModule):
     """


### PR DESCRIPTION
Those changes are included:
* refactor supervisely dataset_params: right order of transformations, fix fill_mask from cityscapes
* Add replace_heads implementation for ppliteseg models