### PR TITLE
FIX: Rename memory_cached

### DIFF
--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -398,7 +398,7 @@ class Trainer:
 
             # COMPUTE THE RUNNING USER METRICS AND LOSS RUNNING ITEMS. RESULT TUPLE IS THEIR CONCATENATION.
             logging_values = loss_avg_meter.average + get_metrics_results_tuple(self.train_metrics)
-            gpu_memory_utilization = torch.cuda.memory_cached() / 1E9 if torch.cuda.is_available() else 0
+            gpu_memory_utilization = torch.cuda.memory_reserved() / 1E9 if torch.cuda.is_available() else 0
 
             # RENDER METRICS PROGRESS
             pbar_message_dict = get_train_loop_description_dict(logging_values,

--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -41,7 +41,7 @@ from super_gradients.training.metrics.metric_utils import get_metrics_titles, ge
     get_metrics_dict, get_train_loop_description_dict
 from super_gradients.training.params import TrainingParams
 from super_gradients.training.utils.distributed_training_utils import MultiGPUModeAutocastWrapper, \
-    reduce_results_tuple_for_ddp, compute_precise_bn_stats, setup_gpu_mode, require_gpu_setup
+    reduce_results_tuple_for_ddp, compute_precise_bn_stats, setup_gpu_mode, require_gpu_setup, get_gpu_mem_utilization
 from super_gradients.training.utils.ema import ModelEMA
 from super_gradients.training.utils.optimizer_utils import build_optimizer
 from super_gradients.training.utils.weight_averaging_utils import ModelWeightAveraging
@@ -398,7 +398,7 @@ class Trainer:
 
             # COMPUTE THE RUNNING USER METRICS AND LOSS RUNNING ITEMS. RESULT TUPLE IS THEIR CONCATENATION.
             logging_values = loss_avg_meter.average + get_metrics_results_tuple(self.train_metrics)
-            gpu_memory_utilization = torch.cuda.memory_reserved() / 1E9 if torch.cuda.is_available() else 0
+            gpu_memory_utilization = get_gpu_mem_utilization() / 1E9 if torch.cuda.is_available() else 0
 
             # RENDER METRICS PROGRESS
             pbar_message_dict = get_train_loop_description_dict(logging_values,

--- a/src/super_gradients/training/utils/distributed_training_utils.py
+++ b/src/super_gradients/training/utils/distributed_training_utils.py
@@ -225,3 +225,13 @@ def restart_script_with_ddp(num_gpus: int = None):
 
     # The code below should actually never be reached as the process will be in a loop inside elastic_launch until any subprocess crashes.
     sys.exit("Main process finished")
+
+
+def get_gpu_mem_utilization():
+    """GPU memory managed by the caching allocator in bytes for a given device."""
+
+    # Workaround to work on any torch version
+    if hasattr(torch.cuda, 'memory_reserved'):
+        return torch.cuda.memory_reserved()
+    else:
+        return torch.cuda.memory_cached()


### PR DESCRIPTION
memory_cached is now deprecated by pytorch and we should use memory_reserved.
This will avoid a lot of warnings that we get in every run