### PR TITLE
Remove AWS env check

### DIFF
--- a/src/super_gradients/common/environment/__init__.py
+++ b/src/super_gradients/common/environment/__init__.py
@@ -1,7 +1,7 @@
 """
 This module is in charge of environment variables and consts.
 """
-from super_gradients.common.environment.environment_config import AWS_ENV_NAME, DDP_LOCAL_RANK
+from super_gradients.common.environment.environment_config import DDP_LOCAL_RANK
 from super_gradients.common.environment.env_helpers import init_trainer, is_distributed
 
-__all__ = ['AWS_ENV_NAME', 'DDP_LOCAL_RANK', 'init_trainer', 'is_distributed']
+__all__ = ['DDP_LOCAL_RANK', 'init_trainer', 'is_distributed']

--- a/src/super_gradients/common/environment/environment_config.py
+++ b/src/super_gradients/common/environment/environment_config.py
@@ -10,21 +10,6 @@ except Exception:
     os.makedirs(os.path.join(os.getcwd(), "checkpoints"), exist_ok=True)
     PKG_CHECKPOINTS_DIR = os.path.join(os.getcwd(), "checkpoints")
 
-AWS_ENV_NAME = environ.get("ENVIRONMENT_NAME")
-
-AWS_ENVIRONMENTS = ["development", "staging", "production"]
-if AWS_ENV_NAME not in AWS_ENVIRONMENTS:
-    if AWS_ENV_NAME is None:
-        if AWS_ENV_NAME not in AWS_ENVIRONMENTS:
-            print(
-                f"You did not mention an AWS environment."
-                f'You can set the environment variable ENVIRONMENT_NAME with one of the values: {",".join(AWS_ENVIRONMENTS)}'
-            )
-        else:
-            print(
-                f'Bad AWS environment name: {AWS_ENV_NAME}. Please set an environment variable named ENVIRONMENT_NAME '
-                f'with one of the values: {",".join(AWS_ENVIRONMENTS)}'
-            )
 
 # Controlling the default logging level via environment variable
 DEFAULT_LOGGING_LEVEL = environ.get("LOG_LEVEL", "INFO").upper()


### PR DESCRIPTION
It seems that the env variable that is checked is never used, am I missing something ?
If it is never used, I don't see a reason to keep the check in the code, especially since it prints a message every time we import SG.
