### PR TITLE
Improve cross-platform compatibility when parsing a readme description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 def get_requirements():
-    with open(REQ_LOCATION) as f:
+    with open(REQ_LOCATION, encoding="utf-8") as f:
         return f.read().splitlines()
 
 


### PR DESCRIPTION
Since README.md is in UTF-8 encoding, open() fails to read the file on non-mac platforms without explicit encoding argument.