### PR TITLE
added useful hydra resolvers with tests

### DIFF
--- a/src/super_gradients/common/environment/env_helpers.py
+++ b/src/super_gradients/common/environment/env_helpers.py
@@ -1,8 +1,8 @@
 import argparse
 import importlib
 import os
-import sys
 import socket
+import sys
 from functools import wraps
 from typing import Any
 
@@ -80,7 +80,6 @@ def init_trainer():
     It resolves conflicts between the different tools, packages and environments used and prepares the super_gradients environment.
     """
     if not environment_config.INIT_TRAINER:
-
         register_hydra_resolvers()
 
         # We pop local_rank if it was specified in the args, because it would break
@@ -95,6 +94,8 @@ def register_hydra_resolvers():
     """Register all the hydra resolvers required for the super-gradients recipes."""
     OmegaConf.register_new_resolver("hydra_output_dir", hydra_output_dir_resolver, replace=True)
     OmegaConf.register_new_resolver("class", lambda *args: get_cls(*args), replace=True)
+    OmegaConf.register_new_resolver("add", lambda *args: sum(args), replace=True)
+    OmegaConf.register_new_resolver("cond", lambda boolean, x, y: x if boolean else y, replace=True)
 
 
 def pop_arg(arg_name: str, default_value: Any = None) -> Any:

--- a/tests/unit_tests/hydra_resolvers_test.py
+++ b/tests/unit_tests/hydra_resolvers_test.py
@@ -1,0 +1,34 @@
+import unittest
+
+from omegaconf import OmegaConf
+
+from super_gradients.common.environment.env_helpers import register_hydra_resolvers
+
+
+class HydraResolversTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        register_hydra_resolvers()
+
+    def test_add(self):
+        conf = OmegaConf.create({
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "a_plus_b": "${add: ${a},${b}}",
+            "a_plus_b_plus_c": "${add: ${a}, ${b}, ${c}}"
+        })
+        assert conf["a_plus_b"] == 3
+        assert conf["a_plus_b_plus_c"] == 6
+
+    def test_cond(self):
+        conf = OmegaConf.create({
+            "boolean": True,
+            "a": "red_pill",
+            "b": "blue_pill",
+            "result": "${cond:${boolean}, ${a}, ${b}}",
+        })
+        assert conf["result"] == "red_pill"
+
+        conf["boolean"] = False
+        assert conf["result"] == "blue_pill"


### PR DESCRIPTION
Tiny pull request for hydra resolvers that I always create for myself and would be helpful to have on SG.
Example use-cases:

`add` - 
```
# in recipe.yaml
num_classes: 19
IoU:
    num_classes: $num_classes + 1                 # not possible right now, very useful
    num_classes: ${add: ${num_classes}, 1}
```

`cond` - 
```
# in recipe.yaml
partial_labels: True
full_num_classes: 19
partial_num classes: 8
n_classes: partial_num_classes if partial_labels else full_num_classes     # a if true else b
n_classes: ${cond: {$partial_labels}, ${partial_num_classes}, ${full_num_classes}}
```