### PR TITLE
when env sanity check fails - print error

### DIFF
--- a/src/super_gradients/sanity_check/env_sanity_check.py
+++ b/src/super_gradients/sanity_check/env_sanity_check.py
@@ -129,7 +129,7 @@ def env_sanity_check():
         elif len(errors) > 0:
             sanity_check_errors[test_name] = errors
             for error in errors:
-                logger.log(stdout_log_level, f"Failed to verify {test_name}: {error}")
+                logger.log(logging.ERROR, f"\33[31mFailed to verify {test_name}: {error}\33[0m")
         else:
             logger.log(stdout_log_level, f'{test_name} OK')
         logger.log(stdout_log_level, '_' * 20)


### PR DESCRIPTION
when env sanity check fails with an error, always print it to the screen and in red