### PR TITLE
Fix: pass extra args to subprocesses in ddp

### DIFF
--- a/src/super_gradients/common/environment/env_helpers.py
+++ b/src/super_gradients/common/environment/env_helpers.py
@@ -15,15 +15,16 @@ class TerminalColours:
     """
     Usage: https://stackoverflow.com/questions/287871/how-to-print-colored-text-in-python?page=1&tab=votes#tab-top
     """
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
 
 
 class ColouredTextFormatter:
@@ -32,7 +33,7 @@ class ColouredTextFormatter:
         """
         Prints a text with colour ascii characters.
         """
-        return print(''.join([colour, text, TerminalColours.ENDC]))
+        return print("".join([colour, text, TerminalColours.ENDC]))
 
 
 def get_cls(cls_path):
@@ -41,8 +42,8 @@ def get_cls(cls_path):
     usage:
     class_of_optimizer: ${class:torch.optim.Adam}
     """
-    module = '.'.join(cls_path.split('.')[:-1])
-    name = cls_path.split('.')[-1]
+    module = ".".join(cls_path.split(".")[:-1])
+    name = cls_path.split(".")[-1]
     importlib.import_module(module)
     return getattr(sys.modules[module], name)
 
@@ -60,13 +61,14 @@ def get_environ_as_type(environment_variable_name: str, default=None, cast_to_ty
         except Exception as e:
             print(e)
             raise ValueError(
-                f'Failed to cast environment variable {environment_variable_name} to type {cast_to_type}: the value {value} is not a valid {cast_to_type}')
+                f"Failed to cast environment variable {environment_variable_name} to type {cast_to_type}: the value {value} is not a valid {cast_to_type}"
+            )
     return
 
 
 def hydra_output_dir_resolver(ckpt_root_dir, experiment_name):
     if ckpt_root_dir is None:
-        output_dir_path = (environment_config.PKG_CHECKPOINTS_DIR + os.path.sep + experiment_name)
+        output_dir_path = environment_config.PKG_CHECKPOINTS_DIR + os.path.sep + experiment_name
     else:
         output_dir_path = ckpt_root_dir + os.path.sep + experiment_name
     return output_dir_path
@@ -96,9 +98,9 @@ def register_hydra_resolvers():
     OmegaConf.register_new_resolver("class", lambda *args: get_cls(*args), replace=True)
     OmegaConf.register_new_resolver("add", lambda *args: sum(args), replace=True)
     OmegaConf.register_new_resolver("cond", lambda boolean, x, y: x if boolean else y, replace=True)
-    OmegaConf.register_new_resolver("getitem", lambda container, key: container[key], replace=True)     # get item from a container (list, dict...)
-    OmegaConf.register_new_resolver("first", lambda lst: lst[0], replace=True)                          # get the first item from a list
-    OmegaConf.register_new_resolver("last", lambda lst: lst[-1], replace=True)                          # get the last item from a list
+    OmegaConf.register_new_resolver("getitem", lambda container, key: container[key], replace=True)  # get item from a container (list, dict...)
+    OmegaConf.register_new_resolver("first", lambda lst: lst[0], replace=True)  # get the first item from a list
+    OmegaConf.register_new_resolver("last", lambda lst: lst[-1], replace=True)  # get the last item from a list
 
 
 def pop_arg(arg_name: str, default_value: Any = None) -> Any:

--- a/src/super_gradients/common/environment/env_helpers.py
+++ b/src/super_gradients/common/environment/env_helpers.py
@@ -112,6 +112,7 @@ def pop_arg(arg_name: str, default_value: Any = None) -> Any:
 
     # Remove the ddp args to not have a conflict with the use of hydra
     for val in filter(lambda x: x.startswith(f"--{arg_name}"), sys.argv):
+        environment_config.EXTRA_ARGS.append(val)
         sys.argv.remove(val)
     return vars(args)[arg_name]
 

--- a/src/super_gradients/common/environment/environment_config.py
+++ b/src/super_gradients/common/environment/environment_config.py
@@ -9,6 +9,7 @@ except Exception:
     PKG_CHECKPOINTS_DIR = os.path.join(os.getcwd(), "checkpoints")
 
 
-DDP_LOCAL_RANK = -1
+DDP_LOCAL_RANK = int(os.getenv("LOCAL_RANK", default=-1))
+EXTRA_ARGS = []
 
 INIT_TRAINER = False

--- a/src/super_gradients/training/utils/checkpoint_utils.py
+++ b/src/super_gradients/training/utils/checkpoint_utils.py
@@ -8,6 +8,7 @@ from super_gradients.common.abstractions.abstract_logger import get_logger
 from super_gradients.common import explicit_params_validation, ADNNModelRepositoryDataInterfaces
 from super_gradients.training.pretrained_models import MODEL_URLS
 from super_gradients.common.environment import environment_config
+
 try:
     from torch.hub import download_url_to_file, load_state_dict_from_url
 except (ModuleNotFoundError, ImportError, NameError):
@@ -50,7 +51,7 @@ def get_ckpt_local_path(source_ckpt_folder_name: str, experiment_name: str, ckpt
     @return:
     """
     source_ckpt_folder_name = source_ckpt_folder_name or experiment_name
-    ckpt_local_path = external_checkpoint_path or pkg_resources.resource_filename('checkpoints', source_ckpt_folder_name + os.path.sep + ckpt_name)
+    ckpt_local_path = external_checkpoint_path or pkg_resources.resource_filename("checkpoints", source_ckpt_folder_name + os.path.sep + ckpt_name)
 
     return ckpt_local_path
 
@@ -65,19 +66,24 @@ def adaptive_load_state_dict(net: torch.nn.Module, state_dict: dict, strict: str
     @return:
     """
     try:
-        net.load_state_dict(state_dict['net'] if 'net' in state_dict.keys() else state_dict, strict=strict)
+        net.load_state_dict(state_dict["net"] if "net" in state_dict.keys() else state_dict, strict=strict)
     except (RuntimeError, ValueError, KeyError) as ex:
-        if strict == 'no_key_matching':
+        if strict == "no_key_matching":
             adapted_state_dict = adapt_state_dict_to_fit_model_layer_names(net.state_dict(), state_dict)
-            net.load_state_dict(adapted_state_dict['net'], strict=True)
+            net.load_state_dict(adapted_state_dict["net"], strict=True)
         else:
             raise_informative_runtime_error(net.state_dict(), state_dict, ex)
 
 
-@explicit_params_validation(validation_type='None')
-def copy_ckpt_to_local_folder(local_ckpt_destination_dir: str, ckpt_filename: str, remote_ckpt_source_dir: str = None,
-                              path_src: str = 'local', overwrite_local_ckpt: bool = False,
-                              load_weights_only: bool = False):
+@explicit_params_validation(validation_type="None")
+def copy_ckpt_to_local_folder(
+    local_ckpt_destination_dir: str,
+    ckpt_filename: str,
+    remote_ckpt_source_dir: str = None,
+    path_src: str = "local",
+    overwrite_local_ckpt: bool = False,
+    load_weights_only: bool = False,
+):
     """
     Copy the checkpoint from any supported source to a local destination path
         :param local_ckpt_destination_dir:  destination where the checkpoint will be saved to
@@ -96,27 +102,31 @@ def copy_ckpt_to_local_folder(local_ckpt_destination_dir: str, ckpt_filename: st
     if not overwrite_local_ckpt:
         # CREATE A TEMP FOLDER TO SAVE THE CHECKPOINT TO
         download_ckpt_destination_dir = tempfile.gettempdir()
-        print('PLEASE NOTICE - YOU ARE IMPORTING A REMOTE CHECKPOINT WITH overwrite_local_checkpoint = False '
-              '-> IT WILL BE REDIRECTED TO A TEMP FOLDER AND DELETED ON MACHINE RESTART')
+        print(
+            "PLEASE NOTICE - YOU ARE IMPORTING A REMOTE CHECKPOINT WITH overwrite_local_checkpoint = False "
+            "-> IT WILL BE REDIRECTED TO A TEMP FOLDER AND DELETED ON MACHINE RESTART"
+        )
     else:
         # SAVE THE CHECKPOINT TO MODEL's FOLDER
-        download_ckpt_destination_dir = pkg_resources.resource_filename('checkpoints', local_ckpt_destination_dir)
+        download_ckpt_destination_dir = pkg_resources.resource_filename("checkpoints", local_ckpt_destination_dir)
 
-    if path_src.startswith('s3'):
+    if path_src.startswith("s3"):
         model_checkpoints_data_interface = ADNNModelRepositoryDataInterfaces(data_connection_location=path_src)
         # DOWNLOAD THE FILE FROM S3 TO THE DESTINATION FOLDER
         ckpt_file_full_local_path = model_checkpoints_data_interface.load_remote_checkpoints_file(
             ckpt_source_remote_dir=remote_ckpt_source_dir,
             ckpt_destination_local_dir=download_ckpt_destination_dir,
             ckpt_file_name=ckpt_filename,
-            overwrite_local_checkpoints_file=overwrite_local_ckpt)
+            overwrite_local_checkpoints_file=overwrite_local_ckpt,
+        )
 
         if not load_weights_only:
             # COPY LOG FILES FROM THE REMOTE DIRECTORY TO THE LOCAL ONE ONLY IF LOADING THE CURRENT MODELs CKPT
-            model_checkpoints_data_interface.load_all_remote_log_files(model_name=remote_ckpt_source_dir,
-                                                                       model_checkpoint_local_dir=download_ckpt_destination_dir)
+            model_checkpoints_data_interface.load_all_remote_log_files(
+                model_name=remote_ckpt_source_dir, model_checkpoint_local_dir=download_ckpt_destination_dir
+            )
 
-    if path_src == 'url':
+    if path_src == "url":
         ckpt_file_full_local_path = download_ckpt_destination_dir + os.path.sep + ckpt_filename
         # DOWNLOAD THE FILE FROM URL TO THE DESTINATION FOLDER
         download_url_to_file(remote_ckpt_source_dir, ckpt_file_full_local_path, progress=True)
@@ -126,7 +136,7 @@ def copy_ckpt_to_local_folder(local_ckpt_destination_dir: str, ckpt_filename: st
 
 def read_ckpt_state_dict(ckpt_path: str, device="cpu"):
     if not os.path.exists(ckpt_path):
-        raise ValueError('Incorrect Checkpoint path')
+        raise ValueError("Incorrect Checkpoint path")
 
     if device == "cuda":
         state_dict = torch.load(ckpt_path)
@@ -136,8 +146,7 @@ def read_ckpt_state_dict(ckpt_path: str, device="cpu"):
     return state_dict
 
 
-def adapt_state_dict_to_fit_model_layer_names(model_state_dict: dict, source_ckpt: dict,
-                                              exclude: list = [], solver: callable = None):
+def adapt_state_dict_to_fit_model_layer_names(model_state_dict: dict, source_ckpt: dict, exclude: list = [], solver: callable = None):
     """
     Given a model state dict and source checkpoints, the method tries to correct the keys in the model_state_dict to fit
     the ckpt in order to properly load the weights into the model. If unsuccessful - returns None
@@ -148,18 +157,17 @@ def adapt_state_dict_to_fit_model_layer_names(model_state_dict: dict, source_ckp
                                         that returns a desired weight for ckpt_val.
         :return: renamed checkpoint dict (if possible)
     """
-    if 'net' in source_ckpt.keys():
-        source_ckpt = source_ckpt['net']
+    if "net" in source_ckpt.keys():
+        source_ckpt = source_ckpt["net"]
     model_state_dict_excluded = {k: v for k, v in model_state_dict.items() if not any(x in k for x in exclude)}
     new_ckpt_dict = {}
     for (ckpt_key, ckpt_val), (model_key, model_val) in zip(source_ckpt.items(), model_state_dict_excluded.items()):
         if solver is not None:
             ckpt_val = solver(ckpt_key, ckpt_val, model_key, model_val)
         if ckpt_val.shape != model_val.shape:
-            raise ValueError(f'ckpt layer {ckpt_key} with shape {ckpt_val.shape} does not match {model_key}'
-                             f' with shape {model_val.shape} in the model')
+            raise ValueError(f"ckpt layer {ckpt_key} with shape {ckpt_val.shape} does not match {model_key}" f" with shape {model_val.shape} in the model")
         new_ckpt_dict[model_key] = ckpt_val
-    return {'net': new_ckpt_dict}
+    return {"net": new_ckpt_dict}
 
 
 def raise_informative_runtime_error(state_dict, checkpoint, exception_msg):
@@ -169,18 +177,21 @@ def raise_informative_runtime_error(state_dict, checkpoint, exception_msg):
     """
     try:
         new_ckpt_dict = adapt_state_dict_to_fit_model_layer_names(state_dict, checkpoint)
-        temp_file = tempfile.NamedTemporaryFile().name + '.pt'
+        temp_file = tempfile.NamedTemporaryFile().name + ".pt"
         torch.save(new_ckpt_dict, temp_file)
-        exception_msg = f"\n{'=' * 200}\n{str(exception_msg)} \nconvert ckpt via the utils.adapt_state_dict_to_fit_" \
-                        f"model_layer_names method\na converted checkpoint file was saved in the path {temp_file}\n{'=' * 200}"
+        exception_msg = (
+            f"\n{'=' * 200}\n{str(exception_msg)} \nconvert ckpt via the utils.adapt_state_dict_to_fit_"
+            f"model_layer_names method\na converted checkpoint file was saved in the path {temp_file}\n{'=' * 200}"
+        )
     except ValueError as ex:  # IN CASE adapt_state_dict_to_fit_model_layer_names WAS UNSUCCESSFUL
         exception_msg = f"\n{'=' * 200} \nThe checkpoint and model shapes do no fit, e.g.: {ex}\n{'=' * 200}"
     finally:
         raise RuntimeError(exception_msg)
 
 
-def load_checkpoint_to_model(ckpt_local_path: str, load_backbone: bool, net: torch.nn.Module, strict: str,
-                             load_weights_only: bool, load_ema_as_net: bool = False):
+def load_checkpoint_to_model(
+    ckpt_local_path: str, load_backbone: bool, net: torch.nn.Module, strict: str, load_weights_only: bool, load_ema_as_net: bool = False
+):
     """
     Loads the state dict in ckpt_local_path to net and returns the checkpoint's state dict.
 
@@ -193,20 +204,20 @@ def load_checkpoint_to_model(ckpt_local_path: str, load_backbone: bool, net: tor
     @return:
     """
     if ckpt_local_path is None or not os.path.exists(ckpt_local_path):
-        error_msg = 'Error - loading Model Checkpoint: Path {} does not exist'.format(ckpt_local_path)
+        error_msg = "Error - loading Model Checkpoint: Path {} does not exist".format(ckpt_local_path)
         raise RuntimeError(error_msg)
 
-    if load_backbone and not hasattr(net, 'backbone'):
+    if load_backbone and not hasattr(net, "backbone"):
         raise ValueError("No backbone attribute in net - Can't load backbone weights")
 
     # LOAD THE LOCAL CHECKPOINT PATH INTO A state_dict OBJECT
     checkpoint = read_ckpt_state_dict(ckpt_path=ckpt_local_path)
 
     if load_ema_as_net:
-        if 'ema_net' not in checkpoint.keys():
+        if "ema_net" not in checkpoint.keys():
             raise ValueError("Can't load ema network- no EMA network stored in checkpoint file")
         else:
-            checkpoint['net'] = checkpoint['ema_net']
+            checkpoint["net"] = checkpoint["ema_net"]
 
     # LOAD THE CHECKPOINTS WEIGHTS TO THE MODEL
     if load_backbone:
@@ -216,7 +227,7 @@ def load_checkpoint_to_model(ckpt_local_path: str, load_backbone: bool, net: tor
 
     if load_weights_only or load_backbone:
         # DISCARD ALL THE DATA STORED IN CHECKPOINT OTHER THAN THE WEIGHTS
-        [checkpoint.pop(key) for key in list(checkpoint.keys()) if key != 'net']
+        [checkpoint.pop(key) for key in list(checkpoint.keys()) if key != "net"]
 
     return checkpoint
 
@@ -238,8 +249,11 @@ def _yolox_ckpt_solver(ckpt_key, ckpt_val, model_key, model_val):
     Helper method for reshaping old pretrained checkpoint's focus weights to 6x6 conv weights.
     """
 
-    if ckpt_val.shape != model_val.shape and ckpt_key == 'module._backbone._modules_list.0.conv.conv.weight' and \
-            model_key == '_backbone._modules_list.0.conv.weight':
+    if (
+        ckpt_val.shape != model_val.shape
+        and ckpt_key == "module._backbone._modules_list.0.conv.conv.weight"
+        and model_key == "_backbone._modules_list.0.conv.weight"
+    ):
         model_val.data[:, :, ::2, ::2] = ckpt_val.data[:, :3]
         model_val.data[:, :, 1::2, ::2] = ckpt_val.data[:, 3:6]
         model_val.data[:, :, ::2, 1::2] = ckpt_val.data[:, 6:9]
@@ -260,25 +274,25 @@ def load_pretrained_weights(model: torch.nn.Module, architecture: str, pretraine
     @param pretrained_weights: name for the pretrianed weights (i.e imagenet)
     @return: None
     """
-    model_url_key = architecture + '_' + str(pretrained_weights)
+    model_url_key = architecture + "_" + str(pretrained_weights)
     if model_url_key not in MODEL_URLS.keys():
         raise MissingPretrainedWeightsException(model_url_key)
 
     url = MODEL_URLS[model_url_key]
-    unique_filename = url.split("https://deci-pretrained-models.s3.amazonaws.com/")[1].replace('/', '_').replace(' ', '_')
-    map_location = torch.device('cpu')
+    unique_filename = url.split("https://deci-pretrained-models.s3.amazonaws.com/")[1].replace("/", "_").replace(" ", "_")
+    map_location = torch.device("cpu")
     pretrained_state_dict = load_state_dict_from_url(url=url, map_location=map_location, file_name=unique_filename)
     _load_weights(architecture, model, pretrained_state_dict)
 
 
 def _load_weights(architecture, model, pretrained_state_dict):
-    if 'ema_net' in pretrained_state_dict.keys():
-        pretrained_state_dict['net'] = pretrained_state_dict['ema_net']
+    if "ema_net" in pretrained_state_dict.keys():
+        pretrained_state_dict["net"] = pretrained_state_dict["ema_net"]
     solver = _yolox_ckpt_solver if "yolox" in architecture else None
-    adapted_pretrained_state_dict = adapt_state_dict_to_fit_model_layer_names(model_state_dict=model.state_dict(),
-                                                                              source_ckpt=pretrained_state_dict,
-                                                                              solver=solver)
-    model.load_state_dict(adapted_pretrained_state_dict['net'], strict=False)
+    adapted_pretrained_state_dict = adapt_state_dict_to_fit_model_layer_names(
+        model_state_dict=model.state_dict(), source_ckpt=pretrained_state_dict, solver=solver
+    )
+    model.load_state_dict(adapted_pretrained_state_dict["net"], strict=False)
 
 
 def load_pretrained_weights_local(model: torch.nn.Module, architecture: str, pretrained_weights: str):
@@ -291,7 +305,7 @@ def load_pretrained_weights_local(model: torch.nn.Module, architecture: str, pre
     @return: None
     """
 
-    map_location = torch.device('cpu')
+    map_location = torch.device("cpu")
 
     pretrained_state_dict = torch.load(pretrained_weights, map_location=map_location)
     _load_weights(architecture, model, pretrained_state_dict)

--- a/src/super_gradients/training/utils/distributed_training_utils.py
+++ b/src/super_gradients/training/utils/distributed_training_utils.py
@@ -13,6 +13,7 @@ from torch.distributed.launcher.api import LaunchConfig, elastic_launch
 from super_gradients.common.data_types.enum import MultiGPUMode
 from super_gradients.common.environment.env_helpers import find_free_port, is_distributed
 from super_gradients.common.abstractions.abstract_logger import get_logger
+from super_gradients.common.environment import environment_config
 
 logger = get_logger(__name__)
 
@@ -228,7 +229,7 @@ def restart_script_with_ddp(num_gpus: int = None):
         metrics_cfg={},
     )
 
-    elastic_launch(config=config, entrypoint=sys.executable)(*sys.argv)
+    elastic_launch(config=config, entrypoint=sys.executable)(*sys.argv, *environment_config.EXTRA_ARGS)
 
     # The code below should actually never be reached as the process will be in a loop inside elastic_launch until any subprocess crashes.
     sys.exit("Main process finished")

--- a/src/super_gradients/training/utils/distributed_training_utils.py
+++ b/src/super_gradients/training/utils/distributed_training_utils.py
@@ -1,4 +1,3 @@
-
 import sys
 import itertools
 from contextlib import contextmanager
@@ -40,13 +39,12 @@ def reduce_results_tuple_for_ddp(validation_results_tuple, device):
             validation_result = validation_result.clone().detach()
         else:
             validation_result = torch.tensor(validation_result)
-        validation_results_list[i] = distributed_all_reduce_tensor_average(tensor=validation_result.to(device),
-                                                                           n=torch.distributed.get_world_size())
+        validation_results_list[i] = distributed_all_reduce_tensor_average(tensor=validation_result.to(device), n=torch.distributed.get_world_size())
     validation_results_tuple = tuple(validation_results_list)
     return validation_results_tuple
 
 
-class MultiGPUModeAutocastWrapper():
+class MultiGPUModeAutocastWrapper:
     def __init__(self, func):
         self.func = func
 
@@ -87,7 +85,7 @@ def scaled_all_reduce(tensors: torch.Tensor, num_gpus: int):
 
 @torch.no_grad()
 def compute_precise_bn_stats(model: nn.Module, loader: torch.utils.data.DataLoader, precise_bn_batch_size: int, num_gpus: int):
-    '''
+    """
     :param model:                   The model being trained (ie: Trainer.net)
     :param loader:                  Training dataloader (ie: Trainer.train_loader)
     :param precise_bn_batch_size:   The effective batch size we want to calculate the batchnorm on. For example, if we are training a model
@@ -96,7 +94,7 @@ def compute_precise_bn_stats(model: nn.Module, loader: torch.utils.data.DataLoad
                                     If precise_bn_batch_size is not provided in the training_params, the latter heuristic
                                     will be taken.
     param num_gpus:                 The number of gpus we are training on
-    '''
+    """
 
     # Compute the number of minibatches to use
     num_iter = int(precise_bn_batch_size / (loader.batch_size * num_gpus)) if precise_bn_batch_size else num_gpus
@@ -204,28 +202,31 @@ def restart_script_with_ddp(num_gpus: int = None):
     if num_gpus > torch.cuda.device_count():
         raise ValueError(f"You specified num_gpus={num_gpus} but only {torch.cuda.device_count()} GPU's are available")
 
-    logger.info("Launching DDP with:\n"
-                f"   - ddp_port = {ddp_port}\n"
-                f"   - num_gpus = {num_gpus}/{torch.cuda.device_count()} available\n"
-                "-------------------------------------\n")
+    logger.info(
+        "Launching DDP with:\n"
+        f"   - ddp_port = {ddp_port}\n"
+        f"   - num_gpus = {num_gpus}/{torch.cuda.device_count()} available\n"
+        "-------------------------------------\n"
+    )
 
     config = LaunchConfig(
         nproc_per_node=num_gpus,
         min_nodes=1,
         max_nodes=1,
-        run_id='none',
-        role='default',
-        rdzv_endpoint=f'127.0.0.1:{ddp_port}',
-        rdzv_backend='static',
-        rdzv_configs={'rank': 0, 'timeout': 900},
+        run_id="none",
+        role="default",
+        rdzv_endpoint=f"127.0.0.1:{ddp_port}",
+        rdzv_backend="static",
+        rdzv_configs={"rank": 0, "timeout": 900},
         rdzv_timeout=-1,
         max_restarts=0,
         monitor_interval=5,
-        start_method='spawn',
+        start_method="spawn",
         log_dir=None,
         redirects=Std.NONE,
         tee=Std.NONE,
-        metrics_cfg={})
+        metrics_cfg={},
+    )
 
     elastic_launch(config=config, entrypoint=sys.executable)(*sys.argv)
 
@@ -237,7 +238,7 @@ def get_gpu_mem_utilization():
     """GPU memory managed by the caching allocator in bytes for a given device."""
 
     # Workaround to work on any torch version
-    if hasattr(torch.cuda, 'memory_reserved'):
+    if hasattr(torch.cuda, "memory_reserved"):
         return torch.cuda.memory_reserved()
     else:
         return torch.cuda.memory_cached()


### PR DESCRIPTION
Currently, we don't pass the extra (non-hydra) args to the subprocesses. e.g. if you run `python my_script.py --config-name=config x=0 --y=1 ` then the subprocesses will get `python my_script.py --config-name=config x=0`. 
This is done so because hydra does not support extra args, so we drop it and currently we lose this information after @hydra.main

Solution: When "poping" the extra non-hydra args, we store them in a variable and which can later on be used when launching DDP subprocesses.

Depends on: https://github.com/Deci-AI/super-gradients/pull/464 (black formatting)