### PR TITLE
Add ignore option for dataloder workers on windows

### DIFF
--- a/src/super_gradients/common/auto_logging/console_logging.py
+++ b/src/super_gradients/common/auto_logging/console_logging.py
@@ -6,7 +6,7 @@ from io import StringIO
 import atexit
 from threading import Lock
 
-from super_gradients.common.environment.env_helpers import multi_process_safe, is_main_process
+from super_gradients.common.environment.env_helpers import multi_process_safe, is_main_process, dataloader_worker_safe
 
 
 class BufferWriter:
@@ -114,6 +114,7 @@ class ConsoleSink:
         self._setup()
         atexit.register(self._flush)  # Flush at the end of the process
 
+    @dataloader_worker_safe
     @multi_process_safe
     def _setup(self):
         """On instantiation, setup the default sink file."""
@@ -136,6 +137,7 @@ class ConsoleSink:
                 f.write("============================================================\n")
         self.stdout.write(f"The console stream is logged into {self.filename}\n")
 
+    @dataloader_worker_safe
     @multi_process_safe
     def _set_location(self, filename: str):
         """Copy and redirect the sink file into another location."""
@@ -154,6 +156,7 @@ class ConsoleSink:
         """Copy and redirect the sink file into another location."""
         _console_sink._set_location(filename)
 
+    @dataloader_worker_safe
     @multi_process_safe
     def _flush(self):
         """Force the flush on stdout and stderr."""


### PR DESCRIPTION
I added a decorator for making sure a function does not run on dataloder workers.
This is needed to protect functions called when importing super_gradients on windows, because it seems that dataloader workers on windows re-import all the packages (see https://pytorch.org/docs/stable/data.html#multi-process-data-loading)

Especially:
<img width="862" alt="image" src="https://user-images.githubusercontent.com/35190946/201915024-4e2973e1-1b98-4df8-97e2-ebb6aab9f603.png">

Still need to be tested on windows