### PR TITLE
explicit min_decoder_channels

### DIFF
--- a/src/super_gradients/recipes/arch_params/unet_default_arch_params.yaml
+++ b/src/super_gradients/recipes/arch_params/unet_default_arch_params.yaml
@@ -35,6 +35,7 @@ decoder_params:
   align_corners: False
   up_factor: 2
   is_skip_list: [True, True, True, True]    # List of flags whether to use feature-map from encoder stage as skip connection or not.
+  min_decoder_channels: 1                   # The minimum num_channels of decoder stages. Useful i.e if we want to keep the width above the num of classes.
 
 dropout: 0.
 final_upsample_factor: 2    # Final upsample scale factor after the segmentation head.

--- a/src/super_gradients/training/models/segmentation_models/unet/unet.py
+++ b/src/super_gradients/training/models/segmentation_models/unet/unet.py
@@ -1,6 +1,5 @@
 import torch.nn as nn
 from typing import Optional, Union, List
-import math
 
 from super_gradients.training.utils import HpmStruct, get_param
 from super_gradients.training import models
@@ -85,8 +84,7 @@ class UNetBase(SegmentationModule):
         # Init Encoder
         self.encoder = Encoder(backbone, context_module)
         # Init Decoder
-        min_decoder_channels = math.ceil(self.num_classes / 8) * 8
-        self.decoder = Decoder(skip_channels_list=self.encoder.get_output_number_of_channels(), min_decoder_channels=min_decoder_channels, **decoder_params)
+        self.decoder = Decoder(skip_channels_list=self.encoder.get_output_number_of_channels(), **decoder_params)
         # Init Segmentation Head
         self.seg_head = nn.Sequential(
             SegmentationHead(


### PR DESCRIPTION
Dynamically setting the minimum num of channels w.r.t the num_classes can cause problems when applying transfer learning.
This parameters should be set explicitly.

