### PR TITLE
Feature/380 function to upload models to platform

### DIFF
--- a/src/super_gradients/common/plugins/deci_client.py
+++ b/src/super_gradients/common/plugins/deci_client.py
@@ -130,7 +130,7 @@ class DeciClient:
                 f"you can override this by passing models.get(... download_required_code=False) and importing the files yourself"
             )
 
-    def add_model(self, model, model_meta_data, optimization_request_form):
+    def upload_model(self, model, model_meta_data, optimization_request_form):
         """
         This function will upload the trained model to the Deci Lab
 

--- a/src/super_gradients/common/plugins/deci_client.py
+++ b/src/super_gradients/common/plugins/deci_client.py
@@ -129,3 +129,17 @@ class DeciClient:
                 f"These files will be downloaded to the same location each time the model is fetched from the deci-client.\n"
                 f"you can override this by passing models.get(... download_required_code=False) and importing the files yourself"
             )
+
+    def add_model(self, model, model_meta_data, optimization_request_form):
+        """
+        This function will upload the trained model to the Deci Lab
+
+        Args:
+            model: The resulting model from the training process
+        """
+        self.lab_client.login(token=os.getenv("DECI_PLATFORM_TOKEN"))
+        self.lab_client.add_model(
+            add_model_request=model_meta_data,
+            optimization_request=optimization_request_form,
+            local_loaded_model=model,
+        )

--- a/src/super_gradients/common/plugins/deci_client.py
+++ b/src/super_gradients/common/plugins/deci_client.py
@@ -10,6 +10,7 @@ import os
 import pkg_resources
 from hydra.core.global_hydra import GlobalHydra
 from omegaconf import DictConfig
+from torch import nn
 
 from super_gradients.common.abstractions.abstract_logger import get_logger
 from super_gradients.training.utils.hydra_utils import normalize_path
@@ -21,7 +22,7 @@ try:
     from deci_lab_client.client import DeciPlatformClient
     from deci_common.data_interfaces.files_data_interface import FilesDataInterface
     from deci_lab_client.models import AutoNACFileName
-    from deci_lab_client import ApiException
+    from deci_lab_client import ApiException, ModelMetadata, OptimizationRequestForm
 except (ImportError, NameError):
     client_enabled = False
 
@@ -130,12 +131,14 @@ class DeciClient:
                 f"you can override this by passing models.get(... download_required_code=False) and importing the files yourself"
             )
 
-    def upload_model(self, model, model_meta_data, optimization_request_form):
+    def upload_model(self, model: nn.Module, model_meta_data: ModelMetadata, optimization_request_form: OptimizationRequestForm):
         """
         This function will upload the trained model to the Deci Lab
 
         Args:
             model: The resulting model from the training process
+            model_meta_data: metadata to accompany the model
+            optimization_request_form: the optimization parameters
         """
         self.lab_client.login(token=os.getenv("DECI_PLATFORM_TOKEN"))
         self.lab_client.add_model(

--- a/tests/integration_tests/deci_lab_export_test.py
+++ b/tests/integration_tests/deci_lab_export_test.py
@@ -96,7 +96,7 @@ class DeciLabUploadTest(unittest.TestCase):
 
         net = ResNet18(num_classes=5, arch_params={})
         client = DeciClient()
-        client.add_model(model=net, model_meta_data=model_meta_data, optimization_request_form=optimization_request_form)
+        client.upload_model(model=net, model_meta_data=model_meta_data, optimization_request_form=optimization_request_form)
 
 
 if __name__ == "__main__":

--- a/tests/integration_tests/deci_lab_export_test.py
+++ b/tests/integration_tests/deci_lab_export_test.py
@@ -1,5 +1,6 @@
 import unittest
 from super_gradients import Trainer
+from super_gradients.common.plugins.deci_client import DeciClient
 from super_gradients.training.dataloaders.dataloaders import classification_test_dataloader
 from super_gradients.training.metrics import Accuracy, Top5
 from super_gradients.training.models import ResNet18
@@ -69,6 +70,33 @@ class DeciLabUploadTest(unittest.TestCase):
 
         your_model_from_repo = deci_lab_callback.platform_client.get_model_by_name(name=new_model_from_repo_name).data
         deci_lab_callback.platform_client.delete_model(your_model_from_repo.model_id)
+
+    def test_upload_function(self):
+        model_meta_data = ModelMetadata(
+            name="model_for_deci_lab_upload_test",
+            primary_batch_size=1,
+            architecture="Resnet18",
+            framework="pytorch",
+            dl_task="classification",
+            input_dimensions=(3, 224, 224),
+            primary_hardware="K80",
+            dataset_name="ImageNet",
+            description="ResNet18 ONNX deci.ai Test",
+            tags=[""],
+        )
+
+        optimization_request_form = OptimizationRequestForm(
+            target_hardware="XEON",
+            target_batch_size=1,
+            target_metric=Metric.LATENCY,
+            optimize_model_size=True,
+            quantization_level=QuantizationLevel.FP16,
+            optimize_autonac=True,
+        )
+
+        net = ResNet18(num_classes=5, arch_params={})
+        client = DeciClient()
+        client.add_model(model=net, model_meta_data=model_meta_data, optimization_request_form=optimization_request_form)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The need for a function that uploads to the platform model (not as part of the callback) was raised. 

The main reason for it is that uploads sometimes fail and therefor a stand-alone platform might help.

Need to mimic the function in the callback external to the callback.

---

QUESTION
Do we prefer this:
```
from ... import DeciClient
client = DeciClient()
client.upload_model(model=..., model_meta_data=..., optimization_request_form=...)
```

or this:
```
from ... import upload_model
upload_model(model=..., model_meta_data=..., optimization_request_form=...)
```