### PR TITLE
Prevent system monitoring to write after calling .close()

### DIFF
--- a/src/super_gradients/common/environment/monitoring/monitoring.py
+++ b/src/super_gradients/common/environment/monitoring/monitoring.py
@@ -66,8 +66,8 @@ class SystemMonitor:
                     ),
                 ]
 
-        self.thread = threading.Thread(target=self._run, daemon=True, name="SystemMonitor")
-        self.thread.start()
+        thread = threading.Thread(target=self._run, daemon=True, name="SystemMonitor")
+        thread.start()
 
     def _run(self):
         """Sample, aggregate and write the statistics regularly."""

--- a/src/super_gradients/common/environment/monitoring/monitoring.py
+++ b/src/super_gradients/common/environment/monitoring/monitoring.py
@@ -66,8 +66,8 @@ class SystemMonitor:
                     ),
                 ]
 
-        thread = threading.Thread(target=self._run, daemon=True, name="SystemMonitor")
-        thread.start()
+        self.thread = threading.Thread(target=self._run, daemon=True, name="SystemMonitor")
+        self.thread.start()
 
     def _run(self):
         """Sample, aggregate and write the statistics regularly."""
@@ -76,6 +76,8 @@ class SystemMonitor:
             for _ in range(self.n_samples_per_aggregate):
                 self._sample()
                 time.sleep(self.sample_interval)
+                if not self.running:
+                    break
             self._aggregate_and_write()
 
     def _init_stat_aggregators(self):

--- a/src/super_gradients/common/sg_loggers/base_sg_logger.py
+++ b/src/super_gradients/common/sg_loggers/base_sg_logger.py
@@ -243,10 +243,10 @@ class BaseSGLogger(AbstractSGLogger):
 
     @multi_process_safe
     def close(self):
-        self.tensorboard_writer.close()
         if self.system_monitor is not None:
             self.system_monitor.close()
             logger.info("[CLEANUP] - Successfully stopped system monitoring process")
+        self.tensorboard_writer.close()
         if self.tensor_board_process is not None:
             try:
                 logger.info("[CLEANUP] - Stopping tensorboard process")


### PR DESCRIPTION
This might lead to a situation where the TB is already closed and yet the system monitoring would try to write on TB