### PR TITLE
Feature/sg 458 support for any user dataloader using dataset registry

### DIFF
--- a/src/super_gradients/common/factories/datasets_factory.py
+++ b/src/super_gradients/common/factories/datasets_factory.py
@@ -1,0 +1,7 @@
+from super_gradients.common.factories.base_factory import BaseFactory
+from super_gradients.training.datasets.all_datasets import ALL_DATASETS
+
+
+class DatasetsFactory(BaseFactory):
+    def __init__(self):
+        super().__init__(ALL_DATASETS)

--- a/src/super_gradients/common/registry/registry.py
+++ b/src/super_gradients/common/registry/registry.py
@@ -8,6 +8,7 @@ from super_gradients.training.losses.all_losses import LOSSES
 from super_gradients.modules.detection_modules import ALL_DETECTION_MODULES
 from super_gradients.training.utils.callbacks.all_callbacks import CALLBACKS
 from super_gradients.training.transforms.all_transforms import TRANSFORMS
+from super_gradients.training.datasets.all_datasets import ALL_DATASETS
 
 
 def create_register_decorator(registry: Dict[str, Callable]) -> Callable:
@@ -49,3 +50,4 @@ register_loss = create_register_decorator(registry=LOSSES)
 register_dataloader = create_register_decorator(registry=ALL_DATALOADERS)
 register_callback = create_register_decorator(registry=CALLBACKS)
 register_transform = create_register_decorator(registry=TRANSFORMS)
+register_dataset = create_register_decorator(registry=ALL_DATASETS)

--- a/src/super_gradients/examples/train_from_recipe_with_dataset_registry/train.py
+++ b/src/super_gradients/examples/train_from_recipe_with_dataset_registry/train.py
@@ -1,0 +1,41 @@
+"""
+The purpose of the example below is to demonstrate the use of registry for a dataset object.
+- We train mobilenet_v2 on a user dataset which is not defined in ALL_DATASETS using the dataset registry.
+- We leverage predefined configs from cifar_10 training recipe in our repo.
+
+In order for the registry to work, we must trigger the registry of the user's objects by importing their module at
+  the top of the training script. Hence, we created a similar script to our classic train_from_recipe but with the imports
+  on top. Once imported, all the registry decorated objects will be resolved (i.e user_mnist_train will be resolved
+  to the dataloader of our user's)
+"""
+
+
+from omegaconf import DictConfig
+import hydra
+import pkg_resources
+from super_gradients import Trainer, init_trainer
+
+# Import the user object classes to trigger the registry
+
+# fmt: off
+from super_gradients.examples.train_from_recipe_with_dataset_registry.user_dataset import MnistDataset  # noqa: F401
+
+# fmt: on
+
+
+@hydra.main(
+    config_path=pkg_resources.resource_filename("super_gradients.recipes", ""),
+    config_name="user_recipe_mnist_as_external_dataset_example.yaml",
+    version_base="1.2",
+)
+def main(cfg: DictConfig) -> None:
+    Trainer.train_from_config(cfg)
+
+
+def run():
+    init_trainer()
+    main()
+
+
+if __name__ == "__main__":
+    run()

--- a/src/super_gradients/examples/train_from_recipe_with_dataset_registry/user_dataset.py
+++ b/src/super_gradients/examples/train_from_recipe_with_dataset_registry/user_dataset.py
@@ -1,0 +1,41 @@
+from typing import Optional, Callable
+
+from torchvision.datasets import MNIST
+from torchvision.transforms import Compose
+
+from super_gradients.common.decorators.factory_decorator import resolve_param
+from super_gradients.common.factories.list_factory import ListFactory
+from super_gradients.common.factories.transforms_factory import TransformsFactory
+from super_gradients.common.registry.registry import register_dataset
+
+
+@register_dataset("MnistDataset")
+class MnistDataset(MNIST):
+    """
+    MNIST Dataset
+
+    :param root:                    Path for the data to be extracted
+    :param train:                   Bool to load training (True) or validation (False) part of the dataset
+    :param transforms:              List of transforms to apply sequentially on sample. Wrapped internally with torchvision.Compose
+    :param target_transform:        Transform to apply to target output
+    :param download:                Download (True) the dataset from source
+    """
+
+    @resolve_param(
+        "transforms", ListFactory(TransformsFactory())
+    )  # RESOLVE TRANFORMS ARG- NOW WE CAN USE SG TRANFORMS, IN A SIMPLE MANNER THROUGH SPECIFYING THEM IN THE RECIPE YAML FILE (SEE DATASET_PARAMS INSIDE IT)
+    def __init__(
+        self,
+        root: str,
+        train: bool = True,
+        transforms: Optional[Callable] = None,
+        target_transform: Optional[Callable] = None,
+        download: bool = False,
+    ) -> None:
+        super().__init__(
+            root=root,
+            train=train,
+            transform=Compose(transforms),
+            target_transform=target_transform,
+            download=download,
+        )

--- a/src/super_gradients/recipes/cifar10_resnet.yaml
+++ b/src/super_gradients/recipes/cifar10_resnet.yaml
@@ -29,7 +29,7 @@ ckpt_root_dir:
 
 architecture: resnet18_cifar
 
-experiment_name: resnet18_cifar88
+experiment_name: resnet18_cifar
 
 
 # THE FOLLOWING PARAMS ARE DIRECTLY USED BY HYDRA

--- a/src/super_gradients/recipes/cifar10_resnet.yaml
+++ b/src/super_gradients/recipes/cifar10_resnet.yaml
@@ -29,7 +29,7 @@ ckpt_root_dir:
 
 architecture: resnet18_cifar
 
-experiment_name: resnet18_cifar
+experiment_name: resnet18_cifar88
 
 
 # THE FOLLOWING PARAMS ARE DIRECTLY USED BY HYDRA

--- a/src/super_gradients/recipes/user_recipe_mnist_as_external_dataset_example.yaml
+++ b/src/super_gradients/recipes/user_recipe_mnist_as_external_dataset_example.yaml
@@ -6,11 +6,6 @@
 #   the top of the training script. Hence, we created a similar script to our classic train_from_recipe but with the imports
 #   on top. Once imported, all the registry decorated objects will be resolved (i.e user_mnist_train will be resolved
 #   to the dataloader of our user's)
-#
-# Differently from user_recipe_mnist_example, here we demonstrate how to use train_from_recipe, without the need to implement a DataLoader class for registry.
-# Instead- we work straight with the user defined datasets, which is the simpler option when one does not need their own DataLoader implementation.
-# We do so by Dropping the train_datalaoder, valid_dataloader fields from the recipe's config, while specifying the dataset arg in
-#   train_dataloader_params, valid_dataloader_params.
 
 defaults:
   - training_hyperparams: cifar10_resnet_train_params
@@ -33,7 +28,7 @@ dataset_params:
     download: True
 
   train_dataloader_params:
-    dataset: Mnist
+    dataset: MnistDataset
     batch_size: 256
     num_workers: 8
     drop_last: False
@@ -48,6 +43,7 @@ dataset_params:
     download: True
 
   val_dataloader_params:
+    dataset: MnistDataset
     batch_size: 512
     num_workers: 8
     drop_last: False

--- a/src/super_gradients/training/dataloaders/dataloaders.py
+++ b/src/super_gradients/training/dataloaders/dataloaders.py
@@ -651,17 +651,22 @@ def get(name: str = None, dataset_params: Dict = None, dataloader_params: Dict =
     :param dataset: torch.utils.data.Dataset to be used instead of passing "name" (i.e for external dataset objects).
     :return: initialized DataLoader.
     """
-    dataset_str = get_param(dataloader_params, "dataset")
-    if dataset_str:
-        if dataset_params is not None:
-            dataset = DatasetsFactory.get({dataset_str: dataset_params})
-        else:
-            dataset = DatasetsFactory.get(dataset_str)
-        _ = dataloader_params.pop("dataset")
-
     if dataset is not None:
         if name or dataset_params:
             raise ValueError("'name' and 'dataset_params' cannot be passed with initialized dataset.")
+
+    dataset_str = get_param(dataloader_params, "dataset")
+
+    if dataset_str:
+        if name or dataset:
+            raise ValueError("'name' and 'datasets' cannot be passed when 'dataset' arg dataloader_params is used as well.")
+        if dataset_params is not None:
+            dataset = DatasetsFactory().get(conf={dataset_str: dataset_params})
+        else:
+            dataset = DatasetsFactory().get(conf=dataset_str)
+        _ = dataloader_params.pop("dataset")
+
+    if dataset is not None:
         dataloader_params = _process_sampler_params(dataloader_params, dataset, {})
         dataloader = DataLoader(dataset=dataset, **dataloader_params)
     elif name not in ALL_DATALOADERS.keys():

--- a/src/super_gradients/training/dataloaders/dataloaders.py
+++ b/src/super_gradients/training/dataloaders/dataloaders.py
@@ -38,6 +38,7 @@ from super_gradients.training.utils.distributed_training_utils import (
 )
 from super_gradients.common.abstractions.abstract_logger import get_logger
 from super_gradients.training.utils.utils import override_default_params_without_nones
+from super_gradients.common.factories.datasets_factory import DatasetsFactory
 
 logger = get_logger(__name__)
 
@@ -650,7 +651,13 @@ def get(name: str = None, dataset_params: Dict = None, dataloader_params: Dict =
     :param dataset: torch.utils.data.Dataset to be used instead of passing "name" (i.e for external dataset objects).
     :return: initialized DataLoader.
     """
-    # if 'dataset' in dataloader_params.keys():
+    dataset_str = get_param(dataloader_params, "dataset")
+    if dataset_str:
+        if dataset_params is not None:
+            dataset = DatasetsFactory.get({dataset_str: dataset_params})
+        else:
+            dataset = DatasetsFactory.get(dataset_str)
+        _ = dataloader_params.pop("dataset")
 
     if dataset is not None:
         if name or dataset_params:

--- a/src/super_gradients/training/dataloaders/dataloaders.py
+++ b/src/super_gradients/training/dataloaders/dataloaders.py
@@ -650,6 +650,7 @@ def get(name: str = None, dataset_params: Dict = None, dataloader_params: Dict =
     :param dataset: torch.utils.data.Dataset to be used instead of passing "name" (i.e for external dataset objects).
     :return: initialized DataLoader.
     """
+    # if 'dataset' in dataloader_params.keys():
 
     if dataset is not None:
         if name or dataset_params:

--- a/src/super_gradients/training/datasets/all_datasets.py
+++ b/src/super_gradients/training/datasets/all_datasets.py
@@ -1,0 +1,27 @@
+from super_gradients.training.datasets.classification_datasets import Cifar10, Cifar100, ImageNetDataset
+from super_gradients.training.datasets.detection_datasets import COCODetectionDataset, DetectionDataset, PascalVOCDetectionDataset
+from super_gradients.training.datasets.segmentation_datasets import (
+    SegmentationDataSet,
+    CoCoSegmentationDataSet,
+    PascalAUG2012SegmentationDataSet,
+    PascalVOC2012SegmentationDataSet,
+    CityscapesDataset,
+    SuperviselyPersonsDataset,
+    PascalVOCAndAUGUnifiedDataset,
+)
+
+ALL_DATASETS = {
+    "Cifar10": Cifar10,
+    "Cifar100": Cifar100,
+    "ImageNetDataset": ImageNetDataset,
+    "COCODetectionDataset": COCODetectionDataset,
+    "DetectionDataset": DetectionDataset,
+    "PascalVOCDetectionDataset": PascalVOCDetectionDataset,
+    "SegmentationDataSet": SegmentationDataSet,
+    "CoCoSegmentationDataSet": CoCoSegmentationDataSet,
+    "PascalAUG2012SegmentationDataSet": PascalAUG2012SegmentationDataSet,
+    "PascalVOC2012SegmentationDataSet": PascalVOC2012SegmentationDataSet,
+    "CityscapesDataset": CityscapesDataset,
+    "SuperviselyPersonsDataset": SuperviselyPersonsDataset,
+    "PascalVOCAndAUGUnifiedDataset": PascalVOCAndAUGUnifiedDataset,
+}

--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -35,7 +35,7 @@ from super_gradients.common.sg_loggers.base_sg_logger import BaseSGLogger
 from super_gradients.training import utils as core_utils, models, dataloaders
 from super_gradients.training.models import SgModule
 from super_gradients.training.pretrained_models import PRETRAINED_NUM_CLASSES
-from super_gradients.training.utils import sg_trainer_utils
+from super_gradients.training.utils import sg_trainer_utils, get_param
 from super_gradients.training.utils.sg_trainer_utils import MonitoredValue, parse_args, log_main_training_params
 from super_gradients.training.exceptions.sg_trainer_exceptions import UnsupportedOptimizerFormat, GPUModeNotSetupError
 from super_gradients.training.losses import LOSSES
@@ -203,12 +203,17 @@ class Trainer:
         trainer = Trainer(**kwargs)
 
         # INSTANTIATE DATA LOADERS
+
         train_dataloader = dataloaders.get(
-            name=cfg.train_dataloader, dataset_params=cfg.dataset_params.train_dataset_params, dataloader_params=cfg.dataset_params.train_dataloader_params
+            name=get_param(cfg, "train_dataloader"),
+            dataset_params=cfg.dataset_params.train_dataset_params,
+            dataloader_params=cfg.dataset_params.train_dataloader_params,
         )
 
         val_dataloader = dataloaders.get(
-            name=cfg.val_dataloader, dataset_params=cfg.dataset_params.val_dataset_params, dataloader_params=cfg.dataset_params.val_dataloader_params
+            name=get_param(cfg, "val_dataloader"),
+            dataset_params=cfg.dataset_params.val_dataset_params,
+            dataloader_params=cfg.dataset_params.val_dataloader_params,
         )
 
         # BUILD NETWORK

--- a/tests/unit_tests/datalaoder_factory_test.py
+++ b/tests/unit_tests/datalaoder_factory_test.py
@@ -2,6 +2,7 @@ import unittest
 
 from torch.utils.data import DataLoader, TensorDataset
 
+from super_gradients.common.registry.registry import register_dataset
 from super_gradients.training.dataloaders.dataloaders import (
     classification_test_dataloader,
     detection_test_dataloader,
@@ -52,6 +53,16 @@ from super_gradients.training.datasets import (
     Cifar10,
     Cifar100,
 )
+import torch
+import numpy as np
+
+
+@register_dataset("FixedLenDataset")
+class FixedLenDataset(TensorDataset):
+    def __init__(self):
+        images = torch.Tensor(np.zeros((10, 3, 32, 32)))
+        ground_truth = torch.LongTensor(np.zeros((10)))
+        super(FixedLenDataset, self).__init__(images, ground_truth)
 
 
 class DataLoaderFactoryTest(unittest.TestCase):
@@ -245,6 +256,10 @@ class DataLoaderFactoryTest(unittest.TestCase):
         dataset = Cifar10(root="./data/cifar10", train=False, download=True)
         dl = get(dataset=dataset, dataloader_params={"batch_size": 256, "num_workers": 8, "drop_last": False, "pin_memory": True})
         self.assertTrue(isinstance(dl, DataLoader))
+
+    def test_get_with_registered_dataset(self):
+        dl = get(dataloader_params={"dataset": "FixedLenDataset", "batch_size": 256, "num_workers": 8, "drop_last": False, "pin_memory": True})
+        self.assertTrue(isinstance(dl.dataset, FixedLenDataset))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Added support for launching recipes when only user has only the dataset class (i.e torch.Dataset).
- Registry + factory added for datasets.
- Example: launching MNIST training using the Mnist dataset alone (no DataLoader implementation).