### PR TITLE
Support models.get from platform when working in master

### DIFF
--- a/src/super_gradients/common/plugins/deci_client.py
+++ b/src/super_gradients/common/plugins/deci_client.py
@@ -27,6 +27,9 @@ except (ImportError, NameError):
     client_enabled = False
 
 
+DEFAULT_SG_VERSION = "3.0.2"
+
+
 class DeciClient:
     """
     A client to deci platform and model zoo.
@@ -43,11 +46,12 @@ class DeciClient:
 
         self.lab_client = DeciPlatformClient()
         GlobalHydra.instance().clear()
-        self.super_gradients_version = None
+
         try:
-            self.super_gradients_version = pkg_resources.get_distribution("super_gradients").version
+            sg_version = pkg_resources.get_distribution("super_gradients").version
+            self.super_gradients_version = sg_version if "rc" not in sg_version else DEFAULT_SG_VERSION
         except pkg_resources.DistributionNotFound:
-            self.super_gradients_version = "3.0.2"
+            self.super_gradients_version = DEFAULT_SG_VERSION
 
     def _get_file(self, model_name: str, file_name: str) -> str:
         try:

--- a/src/super_gradients/common/plugins/deci_client.py
+++ b/src/super_gradients/common/plugins/deci_client.py
@@ -46,6 +46,7 @@ class DeciClient:
         self.lab_client = DeciPlatformClient()
         GlobalHydra.instance().clear()
 
+        self.super_gradients_version = None
         try:
             sg_version = pkg_resources.get_distribution("super_gradients").version
             self.super_gradients_version = sg_version if "rc" not in sg_version else DeciClient._DEFAULT_SG_VERSION

--- a/src/super_gradients/common/plugins/deci_client.py
+++ b/src/super_gradients/common/plugins/deci_client.py
@@ -27,14 +27,13 @@ except (ImportError, NameError):
     client_enabled = False
 
 
-DEFAULT_SG_VERSION = "3.0.2"
-
-
 class DeciClient:
     """
     A client to deci platform and model zoo.
     requires credentials for connection
     """
+
+    _DEFAULT_SG_VERSION = "3.0.2"
 
     def __init__(self):
         if not client_enabled:
@@ -49,9 +48,9 @@ class DeciClient:
 
         try:
             sg_version = pkg_resources.get_distribution("super_gradients").version
-            self.super_gradients_version = sg_version if "rc" not in sg_version else DEFAULT_SG_VERSION
+            self.super_gradients_version = sg_version if "rc" not in sg_version else DeciClient._DEFAULT_SG_VERSION
         except pkg_resources.DistributionNotFound:
-            self.super_gradients_version = DEFAULT_SG_VERSION
+            self.super_gradients_version = DeciClient._DEFAULT_SG_VERSION
 
     def _get_file(self, model_name: str, file_name: str) -> str:
         try:


### PR DESCRIPTION
Problem:
We cannot download a model with models.get if SG is installed from master.

Solution:
In that case, use the default version ('3.0.2' atm)