### PR TITLE
Import AutoLoggerConfig and ConsoleSink separatly

### DIFF
--- a/src/super_gradients/common/abstractions/abstract_logger.py
+++ b/src/super_gradients/common/abstractions/abstract_logger.py
@@ -3,7 +3,7 @@ import logging
 import logging.config
 from typing import Union
 
-from super_gradients.common.auto_logging import AutoLoggerConfig
+from super_gradients.common.auto_logging.auto_logger import AutoLoggerConfig
 
 
 def get_logger(logger_name: str, log_level: Union[str, None] = None) -> logging.Logger:

--- a/src/super_gradients/common/auto_logging/__init__.py
+++ b/src/super_gradients/common/auto_logging/__init__.py
@@ -1,4 +1,0 @@
-from super_gradients.common.auto_logging.auto_logger import AutoLoggerConfig
-from super_gradients.common.auto_logging.console_logging import ConsoleSink
-
-__all__ = ["AutoLoggerConfig", "ConsoleSink"]

--- a/src/super_gradients/common/crash_handler/exception_monitoring_setup.py
+++ b/src/super_gradients/common/crash_handler/exception_monitoring_setup.py
@@ -2,9 +2,10 @@ import os
 import logging
 import atexit
 
-from super_gradients.common.auto_logging.console_logging import ConsoleSink
+
 from super_gradients.common.environment.ddp_utils import multi_process_safe, is_distributed
 from super_gradients.common.crash_handler.exception import ExceptionInfo
+from super_gradients.common.auto_logging.console_logging import ConsoleSink
 
 try:
     from deci_lab_client.client import DeciPlatformClient

--- a/src/super_gradients/common/sg_loggers/base_sg_logger.py
+++ b/src/super_gradients/common/sg_loggers/base_sg_logger.py
@@ -11,12 +11,12 @@ import torch
 from PIL import Image
 from super_gradients.common import ADNNModelRepositoryDataInterfaces
 from super_gradients.common.abstractions.abstract_logger import get_logger
-from super_gradients.common.auto_logging.auto_logger import AutoLoggerConfig
 from super_gradients.common.environment.ddp_utils import multi_process_safe
 from super_gradients.common.sg_loggers.abstract_sg_logger import AbstractSGLogger
 from super_gradients.training.params import TrainingParams
 from super_gradients.training.utils import sg_trainer_utils
 from super_gradients.common.environment.monitoring import SystemMonitor
+from super_gradients.common.auto_logging.auto_logger import AutoLoggerConfig
 from super_gradients.common.auto_logging.console_logging import ConsoleSink
 
 logger = get_logger(__name__)

--- a/src/super_gradients/common/sg_loggers/base_sg_logger.py
+++ b/src/super_gradients/common/sg_loggers/base_sg_logger.py
@@ -11,7 +11,8 @@ import torch
 from PIL import Image
 from super_gradients.common import ADNNModelRepositoryDataInterfaces
 from super_gradients.common.abstractions.abstract_logger import get_logger
-from super_gradients.common.auto_logging import AutoLoggerConfig, ConsoleSink
+from super_gradients.common.auto_logging.auto_logger import AutoLoggerConfig
+from super_gradients.common.auto_logging.console_logging import ConsoleSink
 from super_gradients.common.environment.ddp_utils import multi_process_safe
 from super_gradients.common.sg_loggers.abstract_sg_logger import AbstractSGLogger
 from super_gradients.training.params import TrainingParams

--- a/src/super_gradients/common/sg_loggers/base_sg_logger.py
+++ b/src/super_gradients/common/sg_loggers/base_sg_logger.py
@@ -12,12 +12,12 @@ from PIL import Image
 from super_gradients.common import ADNNModelRepositoryDataInterfaces
 from super_gradients.common.abstractions.abstract_logger import get_logger
 from super_gradients.common.auto_logging.auto_logger import AutoLoggerConfig
-from super_gradients.common.auto_logging.console_logging import ConsoleSink
 from super_gradients.common.environment.ddp_utils import multi_process_safe
 from super_gradients.common.sg_loggers.abstract_sg_logger import AbstractSGLogger
 from super_gradients.training.params import TrainingParams
 from super_gradients.training.utils import sg_trainer_utils
 from super_gradients.common.environment.monitoring import SystemMonitor
+from super_gradients.common.auto_logging.console_logging import ConsoleSink
 
 logger = get_logger(__name__)
 

--- a/tests/unit_tests/train_logging_test.py
+++ b/tests/unit_tests/train_logging_test.py
@@ -1,6 +1,6 @@
 import unittest
 from super_gradients import Trainer
-from super_gradients.common.auto_logging import AutoLoggerConfig
+from super_gradients.common.auto_logging.auto_logger import AutoLoggerConfig
 from super_gradients.training.dataloaders.dataloaders import classification_test_dataloader
 from super_gradients.training.metrics import Accuracy, Top5
 from super_gradients.training.models import ResNet18


### PR DESCRIPTION
Motivation:
- get_logger requires AutoLoggerConfig
- AutoLoggerConfig and ConsoleSink are imported together in the auto_logging package __init__
- ConsoleSink includes some DDP dependencies, which themselves require other imports
This often creates circular import loops that are hard to fix.

Solution:
Not importing ConsoleSink when importing AutoLoggerConfig
