### PR TITLE
Demo shani - how to crash the recipe

### DIFF
--- a/src/super_gradients/recipes/dataset_params/cifar10_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/cifar10_dataset_params.yaml
@@ -8,8 +8,8 @@ train_dataset_params:
   train: True
   transforms:
     - RandomCrop:
-        size: 32
-        padding: 4
+      size: 32
+      padding: 4
     - RandomHorizontalFlip
     - ToTensor
     - Normalize:


### PR DESCRIPTION
Just launch train_from_recipe like usually, on cifar10_resnet
`python train_from_recipe.py --config-name=cifar10_resnet`


Traceback:
```
Traceback (most recent call last):
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/examples/train_from_recipe_example/train_from_recipe.py", line 26, in <module>
    run()
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/examples/train_from_recipe_example/train_from_recipe.py", line 22, in run
    main()
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/main.py", line 90, in decorated_main
    _run_hydra(
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/_internal/utils.py", line 394, in _run_hydra
    _run_app(
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/_internal/utils.py", line 457, in _run_app
    run_and_report(
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/_internal/utils.py", line 222, in run_and_report
    raise ex
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/_internal/utils.py", line 219, in run_and_report
    return func()
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/_internal/utils.py", line 458, in <lambda>
    lambda: hydra.run(
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/_internal/hydra.py", line 132, in run
    _ = ret.return_value
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/core/utils.py", line 260, in return_value
    raise self._return_value
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/core/utils.py", line 186, in run_job
    ret.return_value = task_function(task_cfg)
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/examples/train_from_recipe_example/train_from_recipe.py", line 17, in main
    Trainer.train_from_config(cfg)
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/training/sg_trainer/sg_trainer.py", line 206, in train_from_config
    train_dataloader = dataloaders.get(
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/training/dataloaders/dataloaders.py", line 676, in get
    dataloader = dataloader_cls(dataset_params=dataset_params, dataloader_params=dataloader_params)
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/training/dataloaders/dataloaders.py", line 335, in cifar10_train
    return get_data_loader(
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/training/dataloaders/dataloaders.py", line 77, in get_data_loader
    dataset = dataset_cls(**dataset_params)
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/common/decorators/factory_decorator.py", line 27, in wrapper
    kwargs[param_name] = factory.get(kwargs[param_name])
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/common/factories/transforms_factory.py", line 23, in get
    conf = ListFactory(TransformsFactory()).get(conf)
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/common/factories/list_factory.py", line 15, in get
    all.append(self.factry.get(conf))
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/common/factories/transforms_factory.py", line 25, in get
    return super().get(conf)
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/common/factories/base_factory.py", line 48, in get
    raise RuntimeError("Malformed object definition in configuration. Expecting either a string of object type or a single entry dictionary"
RuntimeError: Malformed object definition in configuration. Expecting either a string of object type or a single entry dictionary{type_name(str): {parameters...}}.received: {'RandomCrop': None, 'size': 32, 'padding': 4}

═══════════════════════════════════════════╦═════════════════════════╦════════════════════════════════════════════════════════════
                                           ║ SuperGradient Crash tip ║ 
                                           ╚═════════════════════════╝ 
Something went wrong! You can find below potential solution(s) to this error: 

1. There is an indentation error in the recipe, while creating RandomCrop.
   If your wrote this in your recipe:
       - RandomCrop:
         size: 32
         padding: 4
   Please change it to:
       - RandomCrop:
           size: 32
           padding: 4
2. If the proposed solution(s) did not help, feel free to contact the SuperGradient team or to open a ticket on https://github.com/Deci-AI/super-gradients/issues/new/choose

see the trace above...
══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════


```


---

Other error:

```
Traceback (most recent call last):
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/examples/train_from_recipe_example/train_from_recipe.py", line 27, in <module>
    run()
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/examples/train_from_recipe_example/train_from_recipe.py", line 23, in run
    main()
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/main.py", line 90, in decorated_main
    _run_hydra(
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/_internal/utils.py", line 394, in _run_hydra
    _run_app(
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/_internal/utils.py", line 457, in _run_app
    run_and_report(
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/_internal/utils.py", line 222, in run_and_report
    raise ex
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/_internal/utils.py", line 219, in run_and_report
    return func()
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/_internal/utils.py", line 458, in <lambda>
    lambda: hydra.run(
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/_internal/hydra.py", line 132, in run
    _ = ret.return_value
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/core/utils.py", line 260, in return_value
    raise self._return_value
  File "/home/louis.dupont/.conda/envs/louis-dev/lib/python3.8/site-packages/hydra/core/utils.py", line 186, in run_job
    ret.return_value = task_function(task_cfg)
  File "/home/louis.dupont/PycharmProjects/super-gradients/src/super_gradients/examples/train_from_recipe_example/train_from_recipe.py", line 17, in main
    raise RuntimeError("Default process group has not been initialized, please make sure to call init_process_group.")
RuntimeError: Default process group has not been initialized, please make sure to call init_process_group.

═══════════════════════════════════════════╦═════════════════════════╦════════════════════════════════════════════════════════════
                                           ║ SuperGradient Crash tip ║ 
                                           ╚═════════════════════════╝ 
Something went wrong! You can find below potential solution(s) to this error: 

1. Your environment was not setup correctly for DDP.
   Please run at the beginning of your script:
   >>> from super_gradients.training.utils.distributed_training_utils import setup_device
   >>> from super_gradients.common.data_types.enum import MultiGPUMode
   >>> setup_device(multi_gpu=MultiGPUMode.DISTRIBUTED_DATA_PARALLEL, num_gpus=...)
2. If the proposed solution(s) did not help, feel free to contact the SuperGradient team or to open a ticket on https://github.com/Deci-AI/super-gradients/issues/new/choose

see the trace above...
══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════

```