### PR TITLE
fix ignore index for DiceCEEdgeLoss

### DIFF
--- a/src/super_gradients/training/losses/dice_ce_edge_loss.py
+++ b/src/super_gradients/training/losses/dice_ce_edge_loss.py
@@ -59,7 +59,7 @@ class DiceCEEdgeLoss(_Loss):
             self.binary_dice = BinaryDiceLoss(apply_sigmoid=True)
 
         self.ce_edge = MaskAttentionLoss(criterion=nn.CrossEntropyLoss(reduction="none", ignore_index=ignore_index), loss_weights=ce_edge_weights)
-        self.dice_loss = DiceLoss(apply_softmax=True, ignore_index=ignore_index)
+        self.dice_loss = DiceLoss(apply_softmax=True, ignore_index=None if ignore_index < 0 else ignore_index)
 
     @property
     def component_names(self):


### PR DESCRIPTION
Torch native cpp loss classes except only integer as ignore_index, the default is -100 for not using ignore.
While python based implementation use `None` as explicit indication for no using an ignore_index, see DiceLoss and torchmetrics.JaccardIndex class signatures.
This PR prevent passing an integer to `DiceLoss` that crash in the `to_one_hot` function due to an extra unnecessary ignore class, as follows:
```
  File "/home/lior.kadoch/PycharmProjects/super-gradients/src/super_gradients/training/losses/dice_loss.py", line 28, in _calc_numerator_denominator
    numerator = labels_one_hot * predict
RuntimeError: The size of tensor a (22) must match the size of tensor b (21) at non-singleton dimension 1
```