### PR TITLE
fixes reference before assignment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   orb_version:
     type: string
     description: Deci ai ORB version https://circleci.com/developer/orbs/orb/deci-ai/circleci-common-orb
-    default: "4.1.3"
+    default: "10.3.0"
 #    default: "dev:alpha"
 
 orbs:
@@ -216,8 +216,7 @@ workflows:
 
   build_and_deploy:
     jobs:
-      - deci-common/persist_version_info:
-          branch: << pipeline.git.branch >>
+      - deci-common/persist_version_info
       - deci-common/codeartifact_login:
           repo_name: "deci-packages"
       - build:

--- a/src/super_gradients/sanity_check/env_sanity_check.py
+++ b/src/super_gradients/sanity_check/env_sanity_check.py
@@ -82,6 +82,7 @@ def verify_installed_libraries() -> List[str]:
 
         lib, required_version_str = requirement.split(constraint)
 
+        upper_limit_version = Version('0.0.0')
         if ",<=" in required_version_str:
             upper_limit_version = Version(required_version_str.split(",<=")[1])
             required_version_str = required_version_str.split(",<=")[0]

--- a/src/super_gradients/sanity_check/env_sanity_check.py
+++ b/src/super_gradients/sanity_check/env_sanity_check.py
@@ -82,7 +82,7 @@ def verify_installed_libraries() -> List[str]:
 
         lib, required_version_str = requirement.split(constraint)
 
-        upper_limit_version = Version('0.0.0')
+        upper_limit_version = Version("0.0.0")
         if ",<=" in required_version_str:
             upper_limit_version = Version(required_version_str.split(",<=")[1])
             required_version_str = required_version_str.split(",<=")[0]


### PR DESCRIPTION
Basically, we can fix the bug by using the suggested PR, or by having dictionary of lambdas:
```python
is_constraint_respected = {
            ">=,<=": lambda: required_version <= installed_version <= upper_limit_version,
            ">=": lambda: installed_version >= required_version,
            "~=": lambda: (
                installed_version.major == required_version.major
                and installed_version.minor == required_version.minor
                and installed_version.micro >= required_version.micro
            ),
            "==": lambda: installed_version == required_version,
        }
        ...
        
        if not is_constraint_respected[constraint]():  # NOTE THE __call__
           ...
```
I guess that the assignment (this PR) is slightly better even though it is less "sophisticated".
Lambdas more robust to such bugs though, so as you wish