### PR TITLE
Interpollation crash tip

### DIFF
--- a/src/super_gradients/common/crash_handler/crash_tips.py
+++ b/src/super_gradients/common/crash_handler/crash_tips.py
@@ -198,12 +198,12 @@ class InterpolationKeyErrorTip(CrashTip):
     def _get_tips(cls, exc_type: type, exc_value: Exception, exc_traceback: TracebackType) -> List[str]:
         variable = re.search("'(.*?)'", str(exc_value)).group(1)
         tip = (
-            f"It looks like you encountered an error related to interpolation and the variable '{variable}'.\n"
+            f"It looks like you encountered an error related to interpolation of the variable '{variable}'.\n"
             "It's possible that this error is caused by not using the full path of the variable in your subfolder configuration.\n"
             f"Please make sure that you are referring to the variable using the "
             f"{fmt_txt('full path starting from the main configuration file', color='green')}.\n"
             f"Try to replace '{fmt_txt(f'${{{variable}}}', color='red')}' with '{fmt_txt(f'${{full.path.to.{variable}}}', color='green')}', "
-            f"where 'path.to' is the actual path to reach 'x' from the root configuration file.\n"
+            f"where 'full.path.to' is the actual path to reach 'x', starting from the root configuration file.\n"
         )
         return [tip]
 

--- a/src/super_gradients/common/crash_handler/crash_tips.py
+++ b/src/super_gradients/common/crash_handler/crash_tips.py
@@ -202,8 +202,8 @@ class InterpolationKeyErrorTip(CrashTip):
             "It's possible that this error is caused by not using the full path of the variable in your subfolder configuration.\n"
             f"Please make sure that you are referring to the variable using the "
             f"{fmt_txt('full path starting from the main configuration file', color='green')}.\n"
-            f"Try to replace '{fmt_txt(f'${{{variable}}}', color='red')}' with '{fmt_txt(f'${{full.path.to.{variable}}}', color='green')}', "
-            f"where 'full.path.to' is the actual path to reach 'x', starting from the root configuration file.\n"
+            f"Try to replace '{fmt_txt(f'${{{variable}}}', color='red')}' with '{fmt_txt(f'${{full.path.to.{variable}}}', color='green')}', \n"
+            f"     where 'full.path.to' is the actual path to reach '{variable}', starting from the root configuration file.\n"
             f"Example: '{fmt_txt('${dataset_params.train_dataloader_params.batch_size}', color='green')}' "
             f"instead of '{fmt_txt('${train_dataloader_params.batch_size}', color='red')}'.\n"
         )

--- a/src/super_gradients/common/crash_handler/crash_tips.py
+++ b/src/super_gradients/common/crash_handler/crash_tips.py
@@ -204,6 +204,8 @@ class InterpolationKeyErrorTip(CrashTip):
             f"{fmt_txt('full path starting from the main configuration file', color='green')}.\n"
             f"Try to replace '{fmt_txt(f'${{{variable}}}', color='red')}' with '{fmt_txt(f'${{full.path.to.{variable}}}', color='green')}', "
             f"where 'full.path.to' is the actual path to reach 'x', starting from the root configuration file.\n"
+            f"Example: '{fmt_txt('${dataset_params.train_dataloader_params.batch_size}', color='green')}' "
+            f"instead of '{fmt_txt('${train_dataloader_params.batch_size}', color='red')}'.\n"
         )
         return [tip]
 

--- a/src/super_gradients/common/crash_handler/crash_tips.py
+++ b/src/super_gradients/common/crash_handler/crash_tips.py
@@ -189,13 +189,9 @@ class WrongHydraVersionTip(CrashTip):
 
 
 class InterpolationKeyErrorTip(CrashTip):
-    """Note: I think that this should be caught within the code instead"""
-
     @classmethod
     def is_relevant(cls, exc_type: type, exc_value: Exception, exc_traceback: TracebackType):
         expected_str = "Interpolation key "
-        print("A ", isinstance(exc_value, omegaconf.errors.InterpolationKeyError), expected_str in str(exc_value))
-        print(str(exc_value))
         return isinstance(exc_value, omegaconf.errors.InterpolationKeyError) and expected_str in str(exc_value)
 
     @classmethod

--- a/tests/unit_tests/crash_tips_test.py
+++ b/tests/unit_tests/crash_tips_test.py
@@ -2,6 +2,7 @@ import sys
 import unittest
 import dataclasses
 from typing import Type
+import omegaconf
 from super_gradients.common.crash_handler.crash_tips import (
     get_relevant_crash_tip_message,
     CrashTip,
@@ -9,6 +10,7 @@ from super_gradients.common.crash_handler.crash_tips import (
     RecipeFactoryFormatTip,
     DDPNotInitializedTip,
     WrongHydraVersionTip,
+    InterpolationKeyErrorTip,
 )
 
 
@@ -45,6 +47,10 @@ class CrashTipTest(unittest.TestCase):
             DocumentedException(
                 exc_value=TypeError("__init__() got an unexpected keyword argument 'version_base'"),
                 expected_crash_tip=WrongHydraVersionTip,
+            ),
+            DocumentedException(
+                exc_value=omegaconf.errors.InterpolationKeyError("omegaconf.errors.InterpolationKeyError: Interpolation key 'x' not found"),
+                expected_crash_tip=InterpolationKeyErrorTip,
             ),
         ]
 


### PR DESCRIPTION
Objectif: Give a hint when people don't write interpolation with full path starting from config file, which is required by hydra

Example: '${dataset_params.train_dataloader_params.batch_size}' (good) instead of '${train_dataloader_params.batch_size}' (bad).

Note: hydra doenst tell us in what config file this breaks so we cannot show the exact solution. Instead we give hints with a general example.

<img width="1387" alt="image" src="https://user-images.githubusercontent.com/35190946/212001521-da3fb9e8-9782-4239-bbdb-147405926fc5.png">
