### PR TITLE
fix default value of max_train_batches, max_valid_batches

### DIFF
--- a/src/super_gradients/recipes/training_hyperparams/default_train_params.yaml
+++ b/src/super_gradients/recipes/training_hyperparams/default_train_params.yaml
@@ -99,10 +99,10 @@ qat_params:
   num_calib_batches: 2 # int, number of batches to collect the statistics from.
   percentile: 99.99 # float, percentile value to use when quant_modules_calib_method='percentile'. Discarded when other methods are used (Default=99.99).
 
-max_train_batches: None,  # For debug- when not None- will break out of inner train loop
+max_train_batches:  # For debug- when not None- will break out of inner train loop
 # (i.e iterating over train_loader) when reaching this number of batches.
 
-max_valid_batches: None,  # For debug- when not None- will break out of inner valid loop
+max_valid_batches:  # For debug- when not None- will break out of inner valid loop
 # (i.e iterating over valid_loader) when reaching this number of batches.
 
 sg_logger: base_sg_logger


### PR DESCRIPTION
### Problem
This "None" breaks the code because it is interpreted as a string.
to reproduce the error, you can run with --config-name=coco2017_yolox
Is it a bug? or did I miss something?

### Fix proposal
Just remove the default value, which automatically sets it to None


