### PR TITLE
Feature/sg 624 remove avg from model plots

### DIFF
--- a/src/super_gradients/training/datasets/segmentation_datasets/coco_segmentation.py
+++ b/src/super_gradients/training/datasets/segmentation_datasets/coco_segmentation.py
@@ -154,6 +154,3 @@ class CoCoSegmentationDataSet(SegmentationDataSet):
         print("Number of images in sub-dataset: ", len(sub_dataset_image_ids))
         torch.save(sub_dataset_image_ids, sub_dataset_image_ids_file_path)
         return sub_dataset_image_ids
-
-
-print("ok")

--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -1392,9 +1392,6 @@ class Trainer:
         self.net.load_state_dict(keep_state_dict)
 
         if not self.ddp_silent_mode:
-            # Adding values to sg_logger
-            # looping over last titles which corresponds to validation (and average model) metrics.
-
             average_model_tb_titles = ["Averaged Model " + x for x in self.results_titles[-1 * len(averaged_model_results_tuple) :]]
             write_struct = ""
             for ind, title in enumerate(average_model_tb_titles):

--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -1394,10 +1394,6 @@ class Trainer:
         if not self.ddp_silent_mode:
             # Adding values to sg_logger
             # looping over last titles which corresponds to validation (and average model) metrics.
-            all_titles = self.results_titles[-1 * len(averaged_model_results_tuple) :]
-            result_dict = {all_titles[i]: averaged_model_results_tuple[i] for i in range(len(averaged_model_results_tuple))}
-
-            self.sg_logger.add_scalars(tag_scalar_dict=result_dict, global_step=self.max_epochs)
 
             average_model_tb_titles = ["Averaged Model " + x for x in self.results_titles[-1 * len(averaged_model_results_tuple) :]]
             write_struct = ""


### PR DESCRIPTION
Currently SG adds the average model at the end of the training graph.

For instance if we train on 300 epochs, at the end of the training SG adds the average model validation metric/loss to the graph, leading to 301 data points on validation plots (vs 300 on training plots).

This is also the case with EarlyStop callback: if trained on 40 epochs, the average model will be added and we will have 41 data points, and even worse: the last point will be displayed at index 300!

This is bad especially since this information is stored in a separate graph (of only 1 data point per training), so I guess we should just remove this behavior.