### PR TITLE
UNet aux heads customization

### DIFF
--- a/src/super_gradients/training/models/segmentation_models/unet/unet.py
+++ b/src/super_gradients/training/models/segmentation_models/unet/unet.py
@@ -90,8 +90,13 @@ class UNetBase(SegmentationModule):
             # backbone features are outputted and set as True in backbone is_out_feature_list.
             aux_heads_params["use_aux_list"] = [a and b for a, b in zip(aux_heads_params["use_aux_list"], backbone_params["is_out_feature_list"])]
             self.aux_heads = self.init_aux_heads(
-                in_channels_list=self.backbone.width_list, upsample_mode=head_upsample_mode, align_corners=align_corners, dropout=dropout, **aux_heads_params
+                in_channels_list=self.encoder.get_all_number_of_channels(),
+                upsample_mode=head_upsample_mode,
+                align_corners=align_corners,
+                dropout=dropout,
+                **aux_heads_params,
             )
+            self.use_aux_feats = [a and b for a, b in zip(aux_heads_params["use_aux_list"], backbone_params["is_out_feature_list"]) if b]
         self.init_params()
 
     @staticmethod
@@ -134,6 +139,7 @@ class UNetBase(SegmentationModule):
         x = self.seg_head(x)
         if not self.use_aux_heads:
             return x
+        encoder_feats = [f for i, f in enumerate(encoder_feats) if self.use_aux_feats[i]]
         aux_feats = [aux_head(feat) for feat, aux_head in zip(encoder_feats[-len(self.aux_heads) :], self.aux_heads)]
         aux_feats.reverse()
         return tuple([x] + aux_feats)

--- a/src/super_gradients/training/models/segmentation_models/unet/unet_encoder.py
+++ b/src/super_gradients/training/models/segmentation_models/unet/unet_encoder.py
@@ -52,6 +52,13 @@ class AbstractUNetBackbone(nn.Module, ABC):
         """
         raise NotImplementedError()
 
+    @abstractmethod
+    def get_all_number_of_channels(self) -> List[int]:
+        """
+        :return: list of stages num channels.
+        """
+        raise NotImplementedError()
+
     def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
         """
         :return: list of skip features from different resolutions to be fused by the decoder.
@@ -261,6 +268,9 @@ class UNetBackboneBase(AbstractUNetBackbone):
     def get_backbone_output_number_of_channels(self) -> List[int]:
         return [ch for ch, is_out in zip(self.width_list, self.is_out_feature_list) if is_out]
 
+    def get_all_number_of_channels(self) -> List[int]:
+        return self.width_list
+
     def forward(self, x):
         outs = []
         for stage, is_out in zip(self.stages, self.is_out_feature_list):
@@ -289,6 +299,12 @@ class Encoder(nn.Module):
         channels_list = self.backbone.get_backbone_output_number_of_channels()
         if hasattr(self.context_module, "out_channels") and self.context_module.out_channels is not None:
             channels_list[-1] = self.context_module.out_channels
+        return channels_list
+
+    def get_all_number_of_channels(self) -> List[int]:
+        channels_list = self.backbone.get_all_number_of_channels()
+        if hasattr(self.context_module, "output_channels"):
+            channels_list[-1] = self.context_module.output_channels()
         return channels_list
 
 


### PR DESCRIPTION
Allow setting any encoder output as auxiliary head with no constraints for the heads to be consecutive (as currently supported)

i.e this example is now supported:
```
# for aux head upsample factor
aux_heads_factor: [ 2, 4, 8, 16, 32, 64 ]

# one can set the aux heads to output only stride 8 and 32, as follows (not supported before this PR):
use_aux_list: [False, False, True, False, True, False]

```