### PR TITLE
Introduce transfer_weights and StrictLoad.KEY_MATCHING mode

### DIFF
--- a/src/super_gradients/common/data_types/enum/strict_load.py
+++ b/src/super_gradients/common/data_types/enum/strict_load.py
@@ -9,8 +9,13 @@ class StrictLoad(Enum):
         ON               - Native torch "strict_load = on" behaviour. See nn.Module.load_state_dict() documentation for more details.
         NO_KEY_MATCHING  - Allows the usage of SuperGradient's adapt_checkpoint function, which loads a checkpoint by matching each
                            layer's shapes (and bypasses the strict matching of the names of each layer (ie: disregards the state_dict key matching)).
+                           This implementation assumes order of layers in the state_dict and model are the same since it goes layer by layer and as name
+                           suggest does not use key matching, relying only on index of each weight.
+        KEY_MATCHING     - Loose load strategy that loads the state dict from checkpoint into model only for common keys and also handling the
+                           case when shapes of the tensors in the state dict and model are different for the same key (Such layers will be skipped).
     """
 
     OFF = False
     ON = True
     NO_KEY_MATCHING = "no_key_matching"
+    KEY_MATCHING = "key_matching"

--- a/src/super_gradients/training/kd_trainer/kd_trainer.py
+++ b/src/super_gradients/training/kd_trainer/kd_trainer.py
@@ -5,7 +5,7 @@ import torch.nn
 from omegaconf import DictConfig, OmegaConf
 from torch.utils.data import DataLoader
 
-from super_gradients.common import MultiGPUMode
+from super_gradients.common import MultiGPUMode, StrictLoad
 from super_gradients.common.abstractions.abstract_logger import get_logger
 from super_gradients.training import utils as core_utils, models
 from super_gradients.training.dataloaders import dataloaders
@@ -226,7 +226,7 @@ class KDTrainer(Trainer):
                 ckpt_local_path=teacher_checkpoint_path,
                 load_backbone=False,
                 net=teacher_net,
-                strict="no_key_matching",
+                strict=StrictLoad.NO_KEY_MATCHING,
                 load_weights_only=True,
                 load_ema_as_net=load_teachers_ema,
             )

--- a/src/super_gradients/training/utils/checkpoint_utils.py
+++ b/src/super_gradients/training/utils/checkpoint_utils.py
@@ -1,14 +1,17 @@
 import os
 import tempfile
 import pkg_resources
-
+import collections
 import torch
 
 from super_gradients.common.abstractions.abstract_logger import get_logger
 from super_gradients.common.data_interface.adnn_model_repository_data_interface import ADNNModelRepositoryDataInterfaces
 from super_gradients.common.decorators.explicit_params_validator import explicit_params_validation
 from super_gradients.training.pretrained_models import MODEL_URLS
+from super_gradients.common.data_types import StrictLoad
 
+from torch import nn, Tensor
+from typing import Union, Mapping
 
 try:
     from torch.hub import download_url_to_file, load_state_dict_from_url
@@ -19,22 +22,44 @@ except (ModuleNotFoundError, ImportError, NameError):
 logger = get_logger(__name__)
 
 
-def adaptive_load_state_dict(net: torch.nn.Module, state_dict: dict, strict: str, solver=None):
+def transfer_weights(model: nn.Module, model_state_dict: Mapping[str, Tensor]) -> None:
+    """
+    Copy weights from `model_state_dict` to `model`, skipping layers that are incompatible (Having different shape).
+    This method is helpful if you are doing some model surgery and want to load
+    part of the model weights into different model.
+    This function will go over all the layers in `model_state_dict` and will try to find a matching layer in `model` and
+    copy the weights into it. If shape will not match, the layer will be skipped.
+
+    :param model: Model to load weights into
+    :param model_state_dict: Model state dict to load weights from
+    :return: None
+    """
+    for name, value in model_state_dict.items():
+        try:
+            model.load_state_dict(collections.OrderedDict([(name, value)]), strict=False)
+        except RuntimeError:
+            pass
+
+
+def adaptive_load_state_dict(net: torch.nn.Module, state_dict: dict, strict: StrictLoad, solver=None):
     """
     Adaptively loads state_dict to net, by adapting the state_dict to net's layer names first.
     :param net: (nn.Module) to load state_dict to
     :param state_dict: (dict) Chekpoint state_dict
-    :param strict: (str) key matching strictness
+    :param strict: (StrictLoad) key matching strictness
     :param solver: callable with signature (ckpt_key, ckpt_val, model_key, model_val)
                      that returns a desired weight for ckpt_val.
     @return:
     """
+    state_dict = state_dict["net"] if "net" in state_dict else state_dict
     try:
-        net.load_state_dict(state_dict["net"] if "net" in state_dict.keys() else state_dict, strict=strict)
+        net.load_state_dict(state_dict, strict=(strict == StrictLoad.ON))
     except (RuntimeError, ValueError, KeyError) as ex:
-        if strict == "no_key_matching":
+        if strict == StrictLoad.NO_KEY_MATCHING:
             adapted_state_dict = adapt_state_dict_to_fit_model_layer_names(net.state_dict(), state_dict, solver=solver)
             net.load_state_dict(adapted_state_dict["net"], strict=True)
+        elif strict == StrictLoad.KEY_MATCHING:
+            transfer_weights(net, state_dict)
         else:
             raise_informative_runtime_error(net.state_dict(), state_dict, ex)
 
@@ -157,7 +182,7 @@ def load_checkpoint_to_model(
     net: torch.nn.Module,
     ckpt_local_path: str,
     load_backbone: bool = False,
-    strict: str = "no_key_matching",
+    strict: Union[str, StrictLoad] = StrictLoad.NO_KEY_MATCHING,
     load_weights_only: bool = False,
     load_ema_as_net: bool = False,
 ):
@@ -172,6 +197,9 @@ def load_checkpoint_to_model(
     @param load_weights_only:
     @return:
     """
+    if isinstance(strict, str):
+        strict = StrictLoad(strict)
+
     if ckpt_local_path is None or not os.path.exists(ckpt_local_path):
         error_msg = "Error - loading Model Checkpoint: Path {} does not exist".format(ckpt_local_path)
         raise RuntimeError(error_msg)
@@ -262,7 +290,7 @@ def _load_weights(architecture, model, pretrained_state_dict):
     if "ema_net" in pretrained_state_dict.keys():
         pretrained_state_dict["net"] = pretrained_state_dict["ema_net"]
     solver = _yolox_ckpt_solver if "yolox" in architecture else None
-    adaptive_load_state_dict(net=model, state_dict=pretrained_state_dict, strict="no_key_matching", solver=solver)
+    adaptive_load_state_dict(net=model, state_dict=pretrained_state_dict, strict=StrictLoad.NO_KEY_MATCHING, solver=solver)
 
 
 def load_pretrained_weights_local(model: torch.nn.Module, architecture: str, pretrained_weights: str):

--- a/tests/deci_core_unit_test_suite_runner.py
+++ b/tests/deci_core_unit_test_suite_runner.py
@@ -26,6 +26,7 @@ from tests.end_to_end_tests import TestTrainer
 from tests.unit_tests.detection_utils_test import TestDetectionUtils
 from tests.unit_tests.detection_dataset_test import DetectionDatasetTest
 from tests.unit_tests.export_onnx_test import TestModelsONNXExport
+from tests.unit_tests.load_checkpoint_test import LoadCheckpointTest
 from tests.unit_tests.local_ckpt_head_replacement_test import LocalCkptHeadReplacementTest
 from tests.unit_tests.max_batches_loop_break_test import MaxBatchesLoopBreakTest
 from tests.unit_tests.phase_delegates_test import ContextMethodsTest
@@ -127,6 +128,7 @@ class CoreUnitTestSuiteRunner:
         self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(TestPPYOLOE))
         self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(DEKRLossTest))
         self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(TestPoseEstimationMetrics))
+        self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(LoadCheckpointTest))
 
     def _add_modules_to_end_to_end_tests_suite(self):
         """

--- a/tests/unit_tests/load_checkpoint_test.py
+++ b/tests/unit_tests/load_checkpoint_test.py
@@ -1,0 +1,31 @@
+import unittest
+
+import torch.nn.init
+from torch import nn
+
+from super_gradients.training.utils.checkpoint_utils import transfer_weights
+
+
+class LoadCheckpointTest(unittest.TestCase):
+    def test_transfer_weights(self):
+        class Foo(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fc1 = nn.Linear(10, 10)
+                self.fc2 = nn.Linear(10, 10)
+                torch.nn.init.zeros_(self.fc1.weight)
+                torch.nn.init.zeros_(self.fc2.weight)
+
+        class Bar(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fc1 = nn.Linear(10, 11)
+                self.fc2 = nn.Linear(10, 10)
+                torch.nn.init.ones_(self.fc1.weight)
+                torch.nn.init.ones_(self.fc2.weight)
+
+        foo = Foo()
+        bar = Bar()
+        self.assertFalse((foo.fc2.weight == bar.fc2.weight).all())
+        transfer_weights(foo, bar.state_dict())
+        self.assertTrue((foo.fc2.weight == bar.fc2.weight).all())


### PR DESCRIPTION
This PR adds `StrictLoad.KEY_MATCHING` mode to do partial checkpoint load. This is different from `.load_state_dict(state_dict, strict=False)` in one but critical part - if the layer has matching name, but shape is different, we will just skip this layer and load what has matching shape, ignoring the rest. Vanilla `load_state_dict` would just raise an error.

See https://github.com/Deci-AI/super-gradients/blob/09c0c0d6ca966a84fc320566fa410fc233770bae/tests/unit_tests/load_checkpoint_test.py#L10 test to get the idea what it does.


The motivation for this change is to have an ability to do partial checkpoint load. In case of DEKR, the pretrained weights comping from another repo and NO_KEY_MATCHING load strategy cannot do the work. `NO_KEY_MATCHING` doing index-based loading and it puts very strict requirement on the order of layers stored in checkpoint (side note: IMO it is very, very, very wroong. We had chat with @shaydeci about this and he explained this is to support some old checkpoints. ).
With `KEY_MATCHING` we could use these pretrained checkpoints without issues. 