### PR TITLE
Remove InfiniteSampler from base configs for COCO

### DIFF
--- a/src/super_gradients/recipes/dataset_params/coco_detection_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/coco_detection_dataset_params.yaml
@@ -46,11 +46,7 @@ train_dataloader_params:
   shuffle: True
   batch_size: 16
   num_workers: 8
-  batch_sampler: True
-  sampler:
-    InfiniteSampler:
-      seed: 0
-  drop_last: False
+  drop_last: True
   pin_memory: True
   worker_init_fn:
     _target_: super_gradients.training.utils.utils.load_func

--- a/src/super_gradients/recipes/dataset_params/coco_detection_ssd_lite_mobilenet_v2_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/coco_detection_ssd_lite_mobilenet_v2_dataset_params.yaml
@@ -42,11 +42,8 @@ train_dataset_params:
 train_dataloader_params:
   batch_size: 32
   num_workers: 8
-  batch_sampler: True
-  sampler:
-    InfiniteSampler:
-      seed: 0
-  drop_last: False
+  shuffle: True
+  drop_last: True
   pin_memory: True
   worker_init_fn:
     _target_: super_gradients.training.utils.utils.load_func

--- a/src/super_gradients/recipes/dataset_params/pascal_voc_detection_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/pascal_voc_detection_dataset_params.yaml
@@ -36,11 +36,7 @@ train_dataloader_params:
   shuffle: True
   batch_size: 16
   num_workers: 8
-  batch_sampler: True
-  sampler:
-    InfiniteSampler:
-      seed: 0
-  drop_last: False
+  drop_last: True
   pin_memory: True
   worker_init_fn:
     _target_: super_gradients.training.utils.utils.load_func

--- a/src/super_gradients/training/datasets/samplers/infinite_sampler.py
+++ b/src/super_gradients/training/datasets/samplers/infinite_sampler.py
@@ -7,6 +7,7 @@ from typing import Optional
 import torch
 import torch.distributed as dist
 from torch.utils.data.sampler import Sampler
+from deprecate import deprecated
 
 
 class InfiniteSampler(Sampler):
@@ -20,6 +21,7 @@ class InfiniteSampler(Sampler):
     or `range(size) + range(size) + ...` (if shuffle is False)
     """
 
+    @deprecated(target=None, deprecated_in="3.0.8", remove_in="3.1.0")
     def __init__(
         self,
         dataset,


### PR DESCRIPTION
This PR removes `InfiniteSampler` from default COCO dataset config. 

The motivation for this change is this class causes random crashes in DataLoader with num_workers > 0. 
It was not traced till the very end, but presumably due to the way this class is implemented (Sampler has no "ending"). 

For instance, following snippet cause crash on Windows:

```

if __name__ == "__main__":
    dataset = list(range(1123123))

    sampler = InfiniteSampler(dataset, shuffle=True, seed=0, rank=0, world_size=1)

    for batch in tqdm(DataLoader(dataset, batch_size=32, drop_last=False, sampler=sampler, num_workers=4), desc="InfiniteSampler"):
        pass

    print("Iterationg over dataset done")

# InfiniteSampler: 100%|█████████▉| 35060/35098 [00:37<00:00, 1220.31it/s]
# Process finished with exit code -1073741819 (0xC0000005)

```



It also ensures that `drop_last: True` is set to avoid rare but possible case when last batch would have size 1 and this would crash training of the model with BatchNormalization layers (They cannot operate on bs=1 in train).

`InfiniteSampler` class is kept in place to avoid breaking change, but annotated with `@deprecated` and will be removed in 3.1.0.


