### PR TITLE
fix: Prevent a wrong warning

### DIFF
--- a/src/super_gradients/training/datasets/data_formats/bbox_formats/cxcywh.py
+++ b/src/super_gradients/training/datasets/data_formats/bbox_formats/cxcywh.py
@@ -94,7 +94,7 @@ def xyxy_to_cxcywh_inplace(bboxes, image_shape: Tuple[int, int]):
                 f"Detected non floating-point ({bboxes.dtype}) input to xyxy_to_cxcywh_inplace function. This may cause rounding errors and lose of precision. "
                 "You may want to convert your array to floating-point precision first."
             )
-        if isinstance(bboxes, np.ndarray) and not isinstance(bboxes.dtype, np.floating):
+        if isinstance(bboxes, np.ndarray) and not isinstance(bboxes.dtype.type, np.floating):
             warnings.warn(
                 f"Detected non floating-point input ({bboxes.dtype}) to xyxy_to_cxcywh_inplace function. This may cause rounding errors and lose of precision. "
                 "You may want to convert your array to floating-point precision first."


### PR DESCRIPTION
Fixing a warning that spams:
`/home/kate.yurkova/super-gradients/src/super_gradients/training/datasets/data_formats/bbox_formats/cxcywh.py:99: UserWarning: Detected non floating-point input (float32) to xyxy_to_cxcywh_inplace function. This may cause rounding errors and lose of precision. You may want to convert your array to floating-point precision first.
  f"Detected non floating-point input ({bboxes.dtype}) to xyxy_to_cxcywh_inplace function. This may cause rounding errors and lose of precision. "
/home/kate.yurkova/super-gradients/src/super_gradients/training/datasets/data_formats/bbox_formats/cxcywh.py:99: UserWarning: Detected non floating-point input (float32) to xyxy_to_cxcywh_inplace function. This may cause rounding errors and lose of precision. You may want to convert your array to floating-point precision first.
  f"Detected non floating-point input ({bboxes.dtype}) to xyxy_to_cxcywh_inplace function. This may cause rounding errors and lose of precision. "
/home/kate.yurkova/super-gradients/src/super_gradients/training/datasets/data_formats/bbox_formats/cxcywh.py:99: UserWarning: Detected non floating-point input (float32) to xyxy_to_cxcywh_inplace function. This may cause rounding errors and lose of precision. You may want to convert your array to floating-point precision first.
  f"Detected non floating-point input ({bboxes.dtype}) to xyxy_to_cxcywh_inplace function. This may cause rounding errors and lose of precision. "`
even though targets are np.float32
See [this](https://stackoverflow.com/a/74651870/9309062) 