### PR TITLE
Fix incorrect tensor type & device when entire batch has no targets

### DIFF
--- a/src/super_gradients/training/losses/ppyolo_loss.py
+++ b/src/super_gradients/training/losses/ppyolo_loss.py
@@ -505,9 +505,9 @@ class TaskAlignedAssigner(nn.Module):
 
         # negative batch
         if num_max_boxes == 0:
-            assigned_labels = torch.full([batch_size, num_anchors], bg_index, dtype="int32")
-            assigned_bboxes = torch.zeros([batch_size, num_anchors, 4])
-            assigned_scores = torch.zeros([batch_size, num_anchors, num_classes])
+            assigned_labels = torch.full([batch_size, num_anchors], bg_index, dtype=torch.long, device=gt_labels.device)
+            assigned_bboxes = torch.zeros([batch_size, num_anchors, 4], device=gt_labels.device)
+            assigned_scores = torch.zeros([batch_size, num_anchors, num_classes], device=gt_labels.device)
             return assigned_labels, assigned_bboxes, assigned_scores
 
         # compute iou between gt and pred bbox, [B, n, L]


### PR DESCRIPTION
Fixes an extremely rare case when batch has zero target bboxes. 