### PR TITLE
Allow activation factory type to take resolved type as input

### DIFF
--- a/src/super_gradients/common/factories/activations_type_factory.py
+++ b/src/super_gradients/common/factories/activations_type_factory.py
@@ -1,5 +1,7 @@
 from typing import Union, Type, Mapping
 
+from torch import nn
+
 from super_gradients.common.factories.base_factory import AbstractFactory
 from super_gradients.training.utils.activations_utils import get_builtin_activation_type
 
@@ -8,12 +10,16 @@ class ActivationsTypeFactory(AbstractFactory):
     """
     This is a special factory for getting a type of the activation function by name.
     This factory does not instantiate a module, but rather return the type to be instantiated via call method.
+
+    Additionally, activation type factory supports already resolved types as input and fall-back to nop if the input is
+    already a type that is subclass of nn.Module. This is done to support the case when the type is already resolved,
+    which is the case when we're using CustomizableDetector.
     """
 
-    def get(self, conf: Union[str, Mapping]) -> Type:
+    def get(self, conf: Union[str, Mapping, Type]) -> Type:
         """
         Get a type.
-           :param conf: a configuration
+           :param conf: a configuration or a type
            if string - assumed to be a type name (not the real name, but a name defined in the Factory)
            a dictionary is not supported, since the actual instantiation takes place elsewhere
 
@@ -26,5 +32,8 @@ class ActivationsTypeFactory(AbstractFactory):
             (type_name,) = list(conf.keys())
             type_args = conf[type_name]
             return get_builtin_activation_type(type_name, **type_args)
+
+        if issubclass(conf, nn.Module):
+            return conf
 
         raise RuntimeError(f"Unsupported conf param type {type(conf)}")

--- a/tests/unit_tests/factories_test.py
+++ b/tests/unit_tests/factories_test.py
@@ -76,6 +76,16 @@ class FactoriesTest(unittest.TestCase):
         model = DummyModel(activation_in_head="leaky_relu")
         self.assertIsInstance(model.activation_in_head, nn.LeakyReLU)
 
+    def test_activations_factory_input_is_type(self):
+        class DummyModel(nn.Module):
+            @resolve_param("activation_in_head", ActivationsTypeFactory())
+            def __init__(self, activation_in_head):
+                super().__init__()
+                self.activation_in_head = activation_in_head()
+
+        model = DummyModel(activation_in_head=nn.LeakyReLU)
+        self.assertIsInstance(model.activation_in_head, nn.LeakyReLU)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is necessary to have this check in ActivationsTypeFactory as when using CustomizableDetector 
activation type could be resolved in top-level blocks and forward down the road to nested blocks as already a type.