### PR TITLE
Feature/sg 757 resume for spots

### DIFF
--- a/src/super_gradients/common/sg_loggers/abstract_sg_logger.py
+++ b/src/super_gradients/common/sg_loggers/abstract_sg_logger.py
@@ -171,6 +171,6 @@ class AbstractSGLogger(ABC):
         """
         raise NotImplementedError
 
-    def download_remote_ckpt(self, *args, **kwargs):
+    def download_remote_ckpt(self, ckpt_name: str, *args, **kwargs):
 
         raise NotImplementedError

--- a/src/super_gradients/common/sg_loggers/abstract_sg_logger.py
+++ b/src/super_gradients/common/sg_loggers/abstract_sg_logger.py
@@ -170,3 +170,7 @@ class AbstractSGLogger(ABC):
         :return:
         """
         raise NotImplementedError
+
+    def download_remote_ckpt(self, *args, **kwargs):
+
+        raise NotImplementedError

--- a/src/super_gradients/common/sg_loggers/base_sg_logger.py
+++ b/src/super_gradients/common/sg_loggers/base_sg_logger.py
@@ -101,6 +101,7 @@ class BaseSGLogger(AbstractSGLogger):
         self._init_system_monitor(monitor_system)
 
         self._save_code()
+        self._resume_from_remote_sg_logger = training_params.resume_from_remote_sg_logger
 
     @multi_process_safe
     def _launch_tensorboard(self, port):

--- a/src/super_gradients/common/sg_loggers/wandb_sg_logger.py
+++ b/src/super_gradients/common/sg_loggers/wandb_sg_logger.py
@@ -95,6 +95,11 @@ class WandBSGLogger(BaseSGLogger):
         self.resumed = resumed
         if self.resumed:
             if wandb_id is None:
+                if self._resume_from_remote_sg_logger:
+                    raise RuntimeError(
+                        "For WandB loggers, when training_params.resume_from_remote_sg_logger=True "
+                        "pass the run id through the wandb_id arg in sg_logger_params"
+                    )
                 wandb_id = self._get_wandb_id()
 
         run = wandb.init(project=project_name, name=experiment_name, entity=entity, resume=resumed, id=wandb_id, **kwargs)

--- a/src/super_gradients/common/sg_loggers/wandb_sg_logger.py
+++ b/src/super_gradients/common/sg_loggers/wandb_sg_logger.py
@@ -91,12 +91,11 @@ class WandBSGLogger(BaseSGLogger):
 
         # allow passing an arbitrary pre-defined wandb_id
         wandb_id = kwargs.pop("wandb_id", None)
+
         self.resumed = resumed
         if self.resumed:
-            if wandb_id is not None:
-                logger.warning("Resuming the run with a previous WandB ID instead of the one from logger params")
-            wandb_id = self._get_wandb_id()
-            wandb.restore
+            if wandb_id is None:
+                wandb_id = self._get_wandb_id()
 
         run = wandb.init(project=project_name, name=experiment_name, entity=entity, resume=resumed, id=wandb_id, **kwargs)
         if save_code:
@@ -317,3 +316,6 @@ class WandBSGLogger(BaseSGLogger):
             return None
 
         return None
+
+    def download_remote_ckpt(self, *args, **kwargs):
+        wandb.restore("ckpt_latest.pth", replace=True, run_path=self.local_dir())

--- a/src/super_gradients/common/sg_loggers/wandb_sg_logger.py
+++ b/src/super_gradients/common/sg_loggers/wandb_sg_logger.py
@@ -318,4 +318,4 @@ class WandBSGLogger(BaseSGLogger):
         return None
 
     def download_remote_ckpt(self, *args, **kwargs):
-        wandb.restore("ckpt_latest.pth", replace=True, run_path=self.local_dir())
+        wandb.restore("ckpt_latest.pth", replace=True, root=self.local_dir())

--- a/src/super_gradients/common/sg_loggers/wandb_sg_logger.py
+++ b/src/super_gradients/common/sg_loggers/wandb_sg_logger.py
@@ -96,6 +96,7 @@ class WandBSGLogger(BaseSGLogger):
             if wandb_id is not None:
                 logger.warning("Resuming the run with a previous WandB ID instead of the one from logger params")
             wandb_id = self._get_wandb_id()
+            wandb.restore
 
         run = wandb.init(project=project_name, name=experiment_name, entity=entity, resume=resumed, id=wandb_id, **kwargs)
         if save_code:

--- a/src/super_gradients/recipes/training_hyperparams/default_train_params.yaml
+++ b/src/super_gradients/recipes/training_hyperparams/default_train_params.yaml
@@ -1,5 +1,14 @@
 resume: False # whether to continue training from ckpt with the same experiment name.
 resume_path: # Explicit checkpoint path (.pth file) to use to resume training.
+
+resume_from_remote_sg_logger: False # bool (default=False), When true, ckpt_name (checkpoint filename
+#        to resume i.e ckpt_latest.pth bydefault) will be downloaded into the experiment checkpoints directory
+#        prior to loading weights, then training is resumed from that checkpoint. The source is unique to
+#        every logger, and currently supported for WandB loggers only.
+#
+#        IMPORTANT: Only works for experiments that were ran with sg_logger_params.save_checkpoints_remote=True.
+#        IMPORTANT: For WandB loggers, one must also pass the run id through the wandb_id arg in sg_logger_params.
+
 ckpt_name: ckpt_latest.pth  # The checkpoint (.pth file) filename in CKPT_ROOT_DIR/EXPERIMENT_NAME/ to use when resume=True and resume_path=None
 lr_mode: # Learning rate scheduling policy, one of ['step','poly','cosine','function']
 lr_schedule_function: # Learning rate scheduling function to be used when `lr_mode` is 'function'.

--- a/src/super_gradients/training/params.py
+++ b/src/super_gradients/training/params.py
@@ -64,9 +64,11 @@ DEFAULT_TRAINING_PARAMS = {
     # (i.e iterating over train_loader) when reaching this number of batches.
     "max_valid_batches": None,  # For debug- when not None- will break out of inner valid loop
     # (i.e iterating over valid_loader) when reaching this number of batches.
-    "download_ckpt_from_sg_logger": False  # When true, ckpt_name (checkpoint filename to resume) will be
-    # downloaded into the experiment checkpoints directory, prior to loading weights (when resume=True).
-    # The source is unique to every logger, and currently supported for WandB loggers only.s
+    "resume_from_remote_sg_logger": False  # When true, ckpt_name (checkpoint filename to resume, ckpt_latest.pth by
+    # default) will be downloaded into the experiment checkpoints directory prior to loading weights, then resumed
+    # from that checkpoint. The source is unique to every logger, and currently supported for WandB loggers only.
+    # Note that for this to work, the experiment must be ran with sg_logger_params.save_checkpoints_remote=True. For
+    # WandB loggers, one must also pass the run id through the wandb_id arg in sg_logger_params.
 }
 
 DEFAULT_OPTIMIZER_PARAMS_SGD = {"weight_decay": 1e-4, "momentum": 0.9}

--- a/src/super_gradients/training/params.py
+++ b/src/super_gradients/training/params.py
@@ -64,6 +64,9 @@ DEFAULT_TRAINING_PARAMS = {
     # (i.e iterating over train_loader) when reaching this number of batches.
     "max_valid_batches": None,  # For debug- when not None- will break out of inner valid loop
     # (i.e iterating over valid_loader) when reaching this number of batches.
+    "download_ckpt_from_sg_logger": False  # When true, ckpt_name (checkpoint filename to resume) will be
+    # downloaded into the experiment checkpoints directory, prior to loading weights (when resume=True).
+    # The source is unique to every logger, and currently supported for WandB loggers only.s
 }
 
 DEFAULT_OPTIMIZER_PARAMS_SGD = {"weight_decay": 1e-4, "momentum": 0.9}

--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -1032,9 +1032,8 @@ class Trainer:
 
         self.net = model
         self._prep_net_for_train()
-        with wait_for_the_master(get_local_rank()):
-            if not self.ddp_silent_mode:
-                self._initialize_sg_logger_objects(additional_configs_to_log)
+        if not self.ddp_silent_mode:
+            self._initialize_sg_logger_objects(additional_configs_to_log)
         self._load_checkpoint_to_model()
 
         # SET RANDOM SEED
@@ -1496,8 +1495,9 @@ class Trainer:
         NOTE: 'acc', 'epoch', 'optimizer_state_dict' and the logs are NOT loaded if self.zeroize_prev_train_params
          is True
         """
-        if self.download_ckpt_from_sg_logger:
-            self.sg_logger.download_remote_ckpt()
+        with wait_for_the_master(get_local_rank()):
+            if self.download_ckpt_from_sg_logger and not self.ddp_silent_mode:
+                self.sg_logger.download_remote_ckpt()
 
         if self.load_checkpoint or self.external_checkpoint_path:
             # GET LOCAL PATH TO THE CHECKPOINT FILE FIRST


### PR DESCRIPTION
Added support for resuming from a remote ckpt stored by the SG logger during training (meaning when sg_logger_params.save_checkpoints_remot=True).


For the base sg logger this is still problematic, as we dont have run ids for S3.
Platform loggers- currently we cant download files from the platform except the ones they explicitly allow, I talked to @roikoren755 and once it will be possible- I will add the mechanism for the platform as well.

Regarding PR content:
- I moved SG Logger initialization to be performed prior to checkpoint loading, so we can download the checkpoint which we wich to resume from.
- I introduced a "resume_from_remote_sg_logger" training param, that when set will download "ckpt_name" into our checkpoints directory, then rsume training from it.