### PR TITLE
Add missing calls to RepVGG blocks to fuse layers

### DIFF
--- a/src/super_gradients/modules/qarepvgg_block.py
+++ b/src/super_gradients/modules/qarepvgg_block.py
@@ -315,3 +315,6 @@ class QARepVGGBlock(nn.Module):
 
     def from_repvgg(self, src: RepVGGBlock):
         raise NotImplementedError
+
+    def prep_model_for_conversion(self, input_size: Optional[Union[tuple, list]] = None, **kwargs):
+        self.full_fusion()

--- a/src/super_gradients/modules/qarepvgg_block.py
+++ b/src/super_gradients/modules/qarepvgg_block.py
@@ -317,4 +317,4 @@ class QARepVGGBlock(nn.Module):
         raise NotImplementedError
 
     def prep_model_for_conversion(self, input_size: Optional[Union[tuple, list]] = None, **kwargs):
-        self.full_fusion()
+        self.partial_fusion()

--- a/src/super_gradients/modules/repvgg_block.py
+++ b/src/super_gradients/modules/repvgg_block.py
@@ -1,4 +1,4 @@
-from typing import Type, Union, Mapping, Any
+from typing import Type, Union, Mapping, Any, Optional
 
 import numpy as np
 import torch
@@ -202,6 +202,9 @@ class RepVGGBlock(nn.Module):
         )
         result.add_module("bn", nn.BatchNorm2d(num_features=out_channels))
         return result
+
+    def prep_model_for_conversion(self, input_size: Optional[Union[tuple, list]] = None, **kwargs):
+        self.fuse_block_residual_branches()
 
 
 def fuse_repvgg_blocks_residual_branches(model: nn.Module):


### PR DESCRIPTION
On the left is unfused, on the right - fused
![image](https://user-images.githubusercontent.com/532320/235894642-244730cf-17db-4c8e-8a25-7e95cf2d4a9c.png)
