### PR TITLE
Fixed false-positive warning message 

### DIFF
--- a/src/super_gradients/training/datasets/data_formats/bbox_formats/cxcywh.py
+++ b/src/super_gradients/training/datasets/data_formats/bbox_formats/cxcywh.py
@@ -98,7 +98,7 @@ def xyxy_to_cxcywh_inplace(bboxes, image_shape: Tuple[int, int]):
                 f"Detected non floating-point ({bboxes.dtype}) input to xyxy_to_cxcywh_inplace function. This may cause rounding errors and lose of precision. "
                 "You may want to convert your array to floating-point precision first."
             )
-        if not is_floating_point_array(bboxes):
+        elif isinstance(bboxes, np.ndarray) and not is_floating_point_array(bboxes):
             warnings.warn(
                 f"Detected non floating-point input ({bboxes.dtype}) to xyxy_to_cxcywh_inplace function. This may cause rounding errors and lose of precision. "
                 "You may want to convert your array to floating-point precision first."


### PR DESCRIPTION
Fix for `.../home/circleci/project/venv/lib/python3.7/site-packages/super_gradients/training/datasets/data_formats/bbox_formats/cxcywh.py:103: UserWarning: Detected non floating-point input (torch.float32) to xyxy_to_cxcywh_inplace function. This may cause rounding errors and lose of precision. You may want to convert your array to floating-point precision first.
`