### PR TITLE
Fix leaking file-handle in logger

### DIFF
--- a/src/super_gradients/common/auto_logging/auto_logger.py
+++ b/src/super_gradients/common/auto_logging/auto_logger.py
@@ -70,6 +70,11 @@ class AutoLoggerConfig:
             )
         else:
             # If the logging does not support force=True, we should manually delete handlers
+            for h in manager.root.handlers:
+                try:
+                    h.close()
+                except AttributeError:
+                    pass
             del manager.root.handlers[:]
 
         if cur_version >= python_39:


### PR DESCRIPTION
This is relevant for tests, that run multiple test cases in the single process.
This PR ensures that we close all file handles before setting up new logger