### PR TITLE
Update deprecate -> deprecated

### DIFF
--- a/src/super_gradients/training/datasets/datasets_utils.py
+++ b/src/super_gradients/training/datasets/datasets_utils.py
@@ -13,7 +13,6 @@ import torch.distributed as dist
 import torch.nn.functional as F
 import torchvision
 from PIL import Image
-from deprecate import deprecated
 from matplotlib.patches import Rectangle
 from torchvision.datasets import ImageFolder
 from torchvision.transforms import transforms, InterpolationMode, RandomResizedCrop
@@ -72,26 +71,6 @@ def get_mean_and_std_torch(data_dir=None, dataloader=None, num_workers=4, Random
     std = torch.sqrt(chsum / (len(trainset) * h * w - 1))
     print(f"std: {std.view(-1)}")
     return mean.view(-1).cpu().numpy().tolist(), std.view(-1).cpu().numpy().tolist()
-
-
-@deprecated(target=get_mean_and_std_torch, deprecated_in="2.1.0", remove_in="3.0.0")
-def get_mean_and_std(dataset):
-    """Compute the mean and std value of dataset."""
-    dataloader = torch.utils.data.DataLoader(dataset, batch_size=1, shuffle=True, num_workers=1)
-    mean = torch.zeros(3)
-    std = torch.zeros(3)
-    print("==> Computing mean and std..")
-    j = 0
-    for inputs, targets in dataloader:
-        if j % 10 == 0:
-            print(j)
-        j += 1
-        for i in range(3):
-            mean[i] += inputs[:, i, :, :].mean()
-            std[i] += inputs[:, i, :, :].std()
-    mean.div_(len(dataset))
-    std.div_(len(dataset))
-    return mean, std
 
 
 class AbstractCollateFunction(ABC):

--- a/src/super_gradients/training/utils/callbacks/callbacks.py
+++ b/src/super_gradients/training/utils/callbacks/callbacks.py
@@ -11,7 +11,7 @@ import numpy as np
 import onnx
 import onnxruntime
 import torch
-from deprecate import deprecated
+from deprecated import deprecated
 
 from super_gradients.common.abstractions.abstract_logger import get_logger
 from super_gradients.common.plugins.deci_client import DeciClient
@@ -476,7 +476,7 @@ class FunctionLRCallback(LRCallbackBase):
     Hard coded rate scheduling for user defined lr scheduling function.
     """
 
-    @deprecated(target=None, deprecated_in="3.6.0", remove_in="4.0.0")
+    @deprecated(version="3.2.0", reason="This callback is deprecated and will be removed in future versions.")
     def __init__(self, max_epochs, lr_schedule_function, **kwargs):
         super(FunctionLRCallback, self).__init__(Phase.TRAIN_BATCH_STEP, **kwargs)
         assert callable(lr_schedule_function), "self.lr_function must be callable"


### PR DESCRIPTION
This small PR fixes wrong import of `deprecate` package that we do not declare in our requirements.
Instead we use `deprecated`. So I changed that. The motivation for this fix is when we loose some of our requirements, the `deprecated` package is not installed anymore and we get import error because of that.