### PR TITLE
Update Weights & Biases integration + Add Inference logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ numpy<=1.23
 rapidfuzz
 json-tricks==3.16.1
 onnx-simplifier>=0.3.6,<1.0
+wandb>=0.15.2

--- a/src/super_gradients/common/sg_loggers/wandb_sg_logger.py
+++ b/src/super_gradients/common/sg_loggers/wandb_sg_logger.py
@@ -97,7 +97,7 @@ class WandBSGLogger(BaseSGLogger):
                 logger.warning("Resuming the run with a previous WandB ID instead of the one from logger params")
             wandb_id = self._get_wandb_id()
 
-        run = wandb.init(project=project_name, name=experiment_name, entity=entity, resume=resumed, id=wandb_id, **kwargs)
+        run = wandb.init(project=project_name, name=experiment_name, entity=entity, resume=resumed, id=wandb_id, **kwargs) if wandb.run is None else wandb.run
         if save_code:
             self._save_code_lines()
 

--- a/src/super_gradients/training/models/prediction_results.py
+++ b/src/super_gradients/training/models/prediction_results.py
@@ -137,7 +137,7 @@ class ImageDetectionPrediction(ImagePrediction):
         """
         image = self.draw(box_thickness=box_thickness, show_confidence=show_confidence, color_mapping=color_mapping)
         show_image(image)
-        
+
         if visualize_on_wandb:
             if wandb.run is None:
                 raise wandb.Error("You must call `wandb.init()` before calling `ImageDetectionPrediction.show(visualize_on_wandb=True)`")
@@ -217,7 +217,13 @@ class ImagesDetectionPrediction(ImagesPredictions):
 
     _images_prediction_lst: List[ImageDetectionPrediction]
 
-    def show(self, box_thickness: int = 2, show_confidence: bool = True, color_mapping: Optional[List[Tuple[int, int, int]]] = None, visualize_on_wandb: bool = False) -> None:
+    def show(
+        self,
+        box_thickness: int = 2,
+        show_confidence: bool = True,
+        color_mapping: Optional[List[Tuple[int, int, int]]] = None,
+        visualize_on_wandb: bool = False
+    ) -> None:
         """Display the predicted bboxes on the images.
 
         :param box_thickness:   Thickness of bounding boxes.

--- a/src/super_gradients/training/models/prediction_results.py
+++ b/src/super_gradients/training/models/prediction_results.py
@@ -69,7 +69,6 @@ class ImageDetectionPrediction(ImagePrediction):
         color_mapping = color_mapping or generate_color_mapping(len(self.class_names))
 
         for pred_i in range(len(self.prediction)):
-
             class_id = int(self.prediction.labels[pred_i])
             score = "" if not show_confidence else str(round(self.prediction.confidence[pred_i], 2))
 
@@ -90,9 +89,7 @@ class ImageDetectionPrediction(ImagePrediction):
         boxes = []
         image = self.image.copy()
         height, width, _ = image.shape
-        class_id_to_labels = {
-            int(_id): str(_class_name) for _id, _class_name in enumerate(self.class_names)
-        }
+        class_id_to_labels = {int(_id): str(_class_name) for _id, _class_name in enumerate(self.class_names)}
 
         for pred_i in range(len(self.prediction)):
             class_id = int(self.prediction.labels[pred_i])
@@ -104,29 +101,18 @@ class ImageDetectionPrediction(ImagePrediction):
                     "maxY": float(int(self.prediction.bboxes_xyxy[pred_i, 3]) / height),
                 },
                 "class_id": int(class_id),
-                "box_caption": str(self.class_names[class_id])
+                "box_caption": str(self.class_names[class_id]),
             }
             if show_confidence:
-                box["scores"] = {
-                    "confidence": float(round(self.prediction.confidence[pred_i], 2))
-                }
+                box["scores"] = {"confidence": float(round(self.prediction.confidence[pred_i], 2))}
             boxes.append(box)
 
-        wandb_image = wandb.Image(image, boxes={
-            "predictions": {
-                "box_data": boxes,
-                "class_labels": class_id_to_labels
-            }
-        })
+        wandb_image = wandb.Image(image, boxes={"predictions": {"box_data": boxes, "class_labels": class_id_to_labels}})
 
         return wandb_image, class_id_to_labels
 
     def show(
-        self,
-        box_thickness: int = 2,
-        show_confidence: bool = True,
-        color_mapping: Optional[List[Tuple[int, int, int]]] = None,
-        visualize_on_wandb: bool = False
+        self, box_thickness: int = 2, show_confidence: bool = True, color_mapping: Optional[List[Tuple[int, int, int]]] = None, visualize_on_wandb: bool = False
     ) -> None:
         """Display the image with predicted bboxes.
 
@@ -218,11 +204,7 @@ class ImagesDetectionPrediction(ImagesPredictions):
     _images_prediction_lst: List[ImageDetectionPrediction]
 
     def show(
-        self,
-        box_thickness: int = 2,
-        show_confidence: bool = True,
-        color_mapping: Optional[List[Tuple[int, int, int]]] = None,
-        visualize_on_wandb: bool = False
+        self, box_thickness: int = 2, show_confidence: bool = True, color_mapping: Optional[List[Tuple[int, int, int]]] = None, visualize_on_wandb: bool = False
     ) -> None:
         """Display the predicted bboxes on the images.
 

--- a/src/super_gradients/training/models/prediction_results.py
+++ b/src/super_gradients/training/models/prediction_results.py
@@ -85,7 +85,7 @@ class ImageDetectionPrediction(ImagePrediction):
             )
 
         return image
-    
+
     def visualize_on_wandb(self, show_confidence: bool = True):
         boxes = []
         image = self.image.copy()
@@ -93,7 +93,7 @@ class ImageDetectionPrediction(ImagePrediction):
         class_id_to_labels = {
             int(_id): str(_class_name) for _id, _class_name in enumerate(self.class_names)
         }
-        
+
         for pred_i in range(len(self.prediction)):
             class_id = int(self.prediction.labels[pred_i])
             box = {
@@ -111,17 +111,23 @@ class ImageDetectionPrediction(ImagePrediction):
                     "confidence": float(round(self.prediction.confidence[pred_i], 2))
                 }
             boxes.append(box)
-        
+
         wandb_image = wandb.Image(image, boxes={
             "predictions": {
                 "box_data": boxes,
                 "class_labels": class_id_to_labels
             }
         })
-        
+
         return wandb_image, class_id_to_labels
 
-    def show(self, box_thickness: int = 2, show_confidence: bool = True, color_mapping: Optional[List[Tuple[int, int, int]]] = None, visualize_on_wandb: bool = False) -> None:
+    def show(
+        self,
+        box_thickness: int = 2,
+        show_confidence: bool = True,
+        color_mapping: Optional[List[Tuple[int, int, int]]] = None,
+        visualize_on_wandb: bool = False
+    ) -> None:
         """Display the image with predicted bboxes.
 
         :param box_thickness:   Thickness of bounding boxes.

--- a/src/super_gradients/training/models/prediction_results.py
+++ b/src/super_gradients/training/models/prediction_results.py
@@ -90,7 +90,9 @@ class ImageDetectionPrediction(ImagePrediction):
         boxes = []
         image = self.image.copy()
         height, width, _ = image.shape
-        class_id_to_labels = {int(_id): str(_class_name) for _id, _class_name in enumerate(self.class_names)}
+        class_id_to_labels = {
+            int(_id): str(_class_name) for _id, _class_name in enumerate(self.class_names)
+        }
         
         for pred_i in range(len(self.prediction)):
             class_id = int(self.prediction.labels[pred_i])


### PR DESCRIPTION
# Changes made in this PR

## Log inference results to Weights & Biases

Fixes https://github.com/Deci-AI/super-gradients/issues/953

Optionally log inference results for object detection in [Weights & Biases](https://wandb.ai/site) dashboard using [bounding-box image overlays](https://docs.wandb.ai/guides/track/log/media#image-overlays).

This PR adds an optional parameter `visualize_on_wandb` to `ImagesDetectionPrediction.show()` which when set to `True` would log the predictions using the [bounding-box image overlays](https://docs.wandb.ai/guides/track/log/media#image-overlays) in the [Weights & Biases](https://wandb.ai/site) dashboard of the user.

Here's a sample code:

```python
from super_gradients.training import models
from super_gradients.common.object_names import Models

import wandb

# Initialize Weights & Biases run
wandb.init(project="yolo-nas", entity="geekyrakshit")

net = models.get(Models.YOLO_NAS_S, pretrained_weights="coco")
prediction = net.predict([
    "https://cdn.autonomous.ai/static/upload/images/common/upload/20210919/5-Desk-Setup-with-a-Laptop--Monitor-Ideas-for-2021_10f89201411b.jpg",
    "https://p.imgci.com/db/PICTURES/CMS/352000/352019.jpg",
    "https://p.imgci.com/db/PICTURES/CMS/352200/352298.jpg",
    "https://www.encirclephotos.com/wp-content/uploads/Laos-Ban-Pak-Ou-Man-Riding-Asian-Elephant-1440x961.jpg"
])
prediction.show(visualize_on_wandb=True)
```

This would log the images to be visualized in a media panel in a Weights & Biases dashboard.

👇 Here's how the results would look
[![](https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28-gray.svg)](https://wandb.ai/geekyrakshit/yolo-nas-integration/runs/lz9mjhwy)

Here's a video of how to interact with the bounding-box overlay interface on Weights & Biases 👇

https://github.com/Deci-AI/super-gradients/assets/19887676/fb027d35-adc1-4e93-9d5a-2ea7b32c50f7

## Optionally decouple `wandb.init()` from `WandBSGLogger`

Fixes https://github.com/Deci-AI/super-gradients/issues/980

`WandBSGLogger` will now call `wandb.init()` only if it has not been called earlier.

👇 Here's a sample training code that works with the changes made in this PR
[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1-HrD-iUedZCHOnfT4topmASE_0RcC5RQ?usp=sharing)

👇 Here's a sample Weights & Biases Run
[![](https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28-gray.svg)](https://wandb.ai/geekyrakshit/yolo-nas-integration/runs/wkuetqdq)