### PR TITLE
Bug/sg 861 decouple qat from train from config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,6 +454,8 @@ jobs:
             python3.8 -m pip install -r requirements.txt
             python3.8 -m pip install .
             python3.8 -m pip install torch torchvision torchaudio
+            python3.8 -m pip install pytorch-quantization==2.1.2 --extra-index-url https://pypi.ngc.nvidia.com
+
             python3.8 src/super_gradients/examples/train_from_recipe_example/train_from_recipe.py --config-name=coco2017_pose_dekr_w32_no_dc experiment_name=shortened_coco2017_pose_dekr_w32_ap_test batch_size=4 val_batch_size=8 epochs=1 training_hyperparams.lr_warmup_steps=0 training_hyperparams.average_best_models=False training_hyperparams.max_train_batches=1000 training_hyperparams.max_valid_batches=100 multi_gpu=DDP num_gpus=4
             python3.8 src/super_gradients/examples/train_from_recipe_example/train_from_recipe.py --config-name=cifar10_resnet experiment_name=shortened_cifar10_resnet_accuracy_test epochs=100 training_hyperparams.average_best_models=False multi_gpu=DDP num_gpus=4
             python3.8 src/super_gradients/examples/convert_recipe_example/convert_recipe_example.py --config-name=cifar10_conversion_params experiment_name=shortened_cifar10_resnet_accuracy_test

--- a/src/super_gradients/__init__.py
+++ b/src/super_gradients/__init__.py
@@ -3,6 +3,7 @@ from super_gradients.training import losses, utils, datasets_utils, DataAugmenta
 from super_gradients.common.registry.registry import ARCHITECTURES
 from super_gradients.sanity_check import env_sanity_check
 from super_gradients.training.utils.distributed_training_utils import setup_device
+from super_gradients.training.pre_launch_callbacks import AutoTrainBatchSizeSelectionCallback, QATRecipeModificationCallback
 
 __all__ = [
     "ARCHITECTURES",
@@ -18,6 +19,8 @@ __all__ = [
     "is_distributed",
     "env_sanity_check",
     "setup_device",
+    "QATRecipeModificationCallback",
+    "AutoTrainBatchSizeSelectionCallback",
 ]
 
 __version__ = "3.1.1"

--- a/src/super_gradients/qat_from_recipe.py
+++ b/src/super_gradients/qat_from_recipe.py
@@ -14,7 +14,7 @@ from super_gradients.training.qat_trainer.qat_trainer import QATTrainer
 
 @hydra.main(config_path="recipes", version_base="1.2")
 def _main(cfg: DictConfig) -> None:
-    QATTrainer.train_from_config(cfg)
+    QATTrainer.quantize_from_config(cfg)
 
 
 def main():

--- a/src/super_gradients/recipes/roboflow_yolo_nas_s_qat.yaml
+++ b/src/super_gradients/recipes/roboflow_yolo_nas_s_qat.yaml
@@ -4,6 +4,7 @@ defaults:
   - _self_
 
 checkpoint_params:
+  checkpoint_path: ???
   strict_load: no_key_matching
 
 pre_launch_callbacks_list:

--- a/src/super_gradients/recipes/roboflow_yolo_nas_s_qat.yaml
+++ b/src/super_gradients/recipes/roboflow_yolo_nas_s_qat.yaml
@@ -4,7 +4,6 @@ defaults:
   - _self_
 
 checkpoint_params:
-  checkpoint_path: ???
   strict_load: no_key_matching
 
 pre_launch_callbacks_list:

--- a/tests/deci_core_recipe_test_suite_runner.py
+++ b/tests/deci_core_recipe_test_suite_runner.py
@@ -2,6 +2,7 @@ import sys
 import unittest
 
 from tests.recipe_training_tests.automatic_batch_selection_single_gpu_test import TestAutoBatchSelectionSingleGPU
+from tests.recipe_training_tests.coded_qat_launch_test import CodedQATLuanchTest
 from tests.recipe_training_tests.shortened_recipes_accuracy_test import ShortenedRecipesAccuracyTests
 
 
@@ -17,6 +18,7 @@ class CoreUnitTestSuiteRunner:
         _add_modules_to_unit_tests_suite - Adds unit tests to the Unit Tests Test Suite
             :return:
         """
+        self.recipe_tests_suite.addTest(self.test_loader.loadTestsFromModule(CodedQATLuanchTest))
         self.recipe_tests_suite.addTest(self.test_loader.loadTestsFromModule(ShortenedRecipesAccuracyTests))
         self.recipe_tests_suite.addTest(self.test_loader.loadTestsFromModule(TestAutoBatchSelectionSingleGPU))
 

--- a/tests/recipe_training_tests/coded_qat_launch_test.py
+++ b/tests/recipe_training_tests/coded_qat_launch_test.py
@@ -1,0 +1,39 @@
+import unittest
+
+from super_gradients import QATTrainer
+from super_gradients.training.dataloaders.dataloaders import classification_test_dataloader
+from super_gradients.training.metrics import Accuracy, Top5
+from super_gradients.training.models import ResNet18
+
+
+class CodedQATLuanchTest(unittest.TestCase):
+    def test_qat_launch(self):
+        trainer = QATTrainer("test_launch_qat_with_minimal_changes")
+        net = ResNet18(num_classes=5, arch_params={})
+        train_params = {
+            "max_epochs": 2,
+            "lr_updates": [1],
+            "lr_decay_factor": 0.1,
+            "lr_mode": "step",
+            "lr_warmup_epochs": 0,
+            "initial_lr": 0.1,
+            "loss": "cross_entropy",
+            "optimizer": "SGD",
+            "criterion_params": {},
+            "optimizer_params": {"weight_decay": 1e-4, "momentum": 0.9},
+            "train_metrics_list": [Accuracy(), Top5()],
+            "valid_metrics_list": [Accuracy(), Top5()],
+            "metric_to_watch": "Accuracy",
+            "greater_metric_to_watch_is_better": True,
+        }
+        trainer.train(
+            model=net,
+            training_params=train_params,
+            train_loader=classification_test_dataloader(batch_size=10),
+            valid_loader=classification_test_dataloader(batch_size=10),
+        )
+        trainer.quantize(calib_dataloader=classification_test_dataloader(batch_size=10))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR decouples QAT/PTQ from train_from_config.
The goal is to let users launch PTQ/QAT using Python instead of CLI + configs, while using as much defaults as possible.
Note that automatic adaptation of the parameters using the best practices is the users responsibilty when they choose to launch this way, since the new "quantize" method I added can expect objects rather then parameters.

- Renamed train_from_config in QATTrainer to quantize_from_config.
- Introduced a "quantize" method.
- Added the option to pass little parameters as possible to let users use existing objects which are already set in train().
- I added a simple test that takes a model from train to QAT to our recipe test suite (modified th ci config to install pytorch quantisation beforehand - it is possible since these tests run on gpu on spot instances).
- Added alot of docs as there were barely any.