### PR TITLE
Feature/sg 815 fix override dataset params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+unit_tests:
+	python -m unittest tests/deci_core_unit_test_suite_runner.py
+
+integration_tests:
+	python -m unittest tests/deci_core_integration_test_suite_runner.py
+
+yolo_nas_integration_tests:
+	python -m unittest tests/integration_tests/yolo_nas_integration_test.py

--- a/src/super_gradients/recipes/dataset_params/coco_detection_yolo_nas_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/coco_detection_yolo_nas_dataset_params.yaml
@@ -31,7 +31,7 @@ train_dataset_params:
         prob: 0.5                       # probability to apply per-sample mixup
         flip_prob: 0.5                  # probability to apply horizontal flip
     - DetectionPaddedRescale:
-        input_dim: [640, 640]
+        input_dim: ${dataset_params.train_dataset_params.input_dim}
         max_targets: 120
         pad_value: 114
     - DetectionStandardize:

--- a/tests/unit_tests/detection_dataset_test.py
+++ b/tests/unit_tests/detection_dataset_test.py
@@ -1,6 +1,7 @@
 import unittest
 from pathlib import Path
 
+from super_gradients.training.dataloaders import coco2017_train_yolo_nas
 from super_gradients.training.datasets import COCODetectionDataset
 from super_gradients.training.exceptions.dataset_exceptions import DatasetValidationException, ParameterMismatchException
 
@@ -43,6 +44,18 @@ class DetectionDatasetTest(unittest.TestCase):
         }
         with self.assertRaises(ParameterMismatchException):
             COCODetectionDataset(**train_dataset_params)
+
+    def test_coco_detection_dataset_override_image_size(self):
+        train_dataset_params = {
+            "data_dir": self.mini_coco_data_dir,
+            "input_dim": [512, 512],
+        }
+        train_dataloader_params = {"num_workers": 0}
+        dataloader = coco2017_train_yolo_nas(dataset_params=train_dataset_params, dataloader_params=train_dataloader_params)
+        batch = next(iter(dataloader))
+        print(batch[0].shape)
+        self.assertEqual(batch[0].shape[2], 512)
+        self.assertEqual(batch[0].shape[3], 512)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/detection_utils_test.py
+++ b/tests/unit_tests/detection_utils_test.py
@@ -28,7 +28,8 @@ class TestDetectionUtils(unittest.TestCase):
         post_prediction_callback = YoloPostPredictionCallback()
 
         # Simulate one iteration of validation subset
-        batch_i, (imgs, targets) = 0, next(iter(valid_loader))
+        batch_i, batch = 0, next(iter(valid_loader))
+        imgs, targets = batch[:2]
         imgs = core_utils.tensor_container_to_device(imgs, self.device)
         targets = core_utils.tensor_container_to_device(targets, self.device)
         output = self.model(imgs)

--- a/tests/unit_tests/detection_utils_test.py
+++ b/tests/unit_tests/detection_utils_test.py
@@ -62,7 +62,9 @@ class TestDetectionUtils(unittest.TestCase):
 
         for met, ref_val in zip(metrics, ref_values):
             met.reset()
-            for i, (imgs, targets) in enumerate(valid_loader):
+            for i, batch in enumerate(valid_loader):
+                # Batch may contain extra data (crowd targets) that are not used
+                imgs, targets = batch[:2]
                 if i > 5:
                     break
                 imgs = core_utils.tensor_container_to_device(imgs, self.device)

--- a/tests/unit_tests/detection_utils_test.py
+++ b/tests/unit_tests/detection_utils_test.py
@@ -47,7 +47,7 @@ class TestDetectionUtils(unittest.TestCase):
     @unittest.skipIf(not is_data_available(), "run only when /data is available")
     def test_detection_metrics(self):
 
-        valid_loader = coco2017_val(dataloader_params={"batch_size": 16})
+        valid_loader = coco2017_val(dataset_params={"with_crowd": False}, dataloader_params={"batch_size": 16})
 
         metrics = [
             DetectionMetrics(num_cls=80, post_prediction_callback=YoloPostPredictionCallback(), normalize_targets=True),


### PR DESCRIPTION
This PR fixes interpolation issue in our dataset configs.
There are two distinct use cases which are almost mutually exclusive, but looks like I managed to get them both working.

## Scenario 1: Colab users

In colab, users override params via dataloader factory methods as follows:

```
dataset = coco2017_train_yolo_nas(dataset_params=dict(data_dir="e:/coco2017", input_dim=[320,320]))
```

Under the hood, we load dataset config from YAML file and apply user-provided overrides.


## Scenario 2: Pycharm / Command line users

In command-line users are launching training with `train_from_recipe` and instantiation of the datasets is somewhat crooked. Since we still calling `coco2017_train_yolo_nas`, but we do a double work of merging a configuration for dataset.

In the call to `coco2017_train_yolo_nas(dataset_params)`  the `dataset_params` variable comes from experiment configuration file  with all the interpolations/instantiations done by hydra for us.
And inside the function `coco2017_train_yolo_nas` still loads `default` dataset params from YAML file.
And them we do the "merging".

The interpolation did not work as intended because of wrong order of instantiation/merging/overrides.
Looks like this PR addresses both scenarios. There are additional unit test cases which tests new logic of merging configs.
I've also ran full set of unit & integration tests on tzags


## Not fixed yet 
(And I'm not sure how)
The COCO YOLO-NAS dataset recipe has this strange image preprocessing of resizing image to longest size of 636 and then padding to 640. Why this is the problem:
*We cannot use interpolation in this case for obvious reasons*
```yaml
val_dataset_params:
  ...
  input_dim: [636, 636]
  transforms:
    - DetectionPadToSize:
        output_size: [640, 640]
    ...
    - DetectionTargetsFormatTransform:
        input_dim: [640, 640]
```

Solution 1: Change input_dim: [636, 636] to input_dim: [640, 640]
Pros: Can use interpolation
Cons: Lose a few decimals of mAP

Solution 2: Leave as is
Pros: None? 
Cons: This recipe would not support changing image resolution via command line or colab

