### PR TITLE
Fixed resuming training with DDP when average_best_models=true

### DIFF
--- a/src/super_gradients/training/utils/weight_averaging_utils.py
+++ b/src/super_gradients/training/utils/weight_averaging_utils.py
@@ -49,7 +49,7 @@ class ModelWeightAveraging:
             else:
                 averaging_snapshots_dict["snapshots_metric"] = np.inf * np.ones(self.number_of_models_to_average)
 
-        torch.save(averaging_snapshots_dict, self.averaging_snapshots_file)
+            torch.save(averaging_snapshots_dict, self.averaging_snapshots_file)
 
     def update_snapshots_dict(self, model, validation_results_tuple):
         """


### PR DESCRIPTION
- In line 52 we save the state dict even if it was just read. Saving is just for the first time we create the state_dict of the snapshots, so the saving is moved inside the else statement when we check if we resume or not.