### PR TITLE
Bug/sg 896 add deprecation for previous breaking changes

### DIFF
--- a/src/super_gradients/training/datasets/samplers/__init__.py
+++ b/src/super_gradients/training/datasets/samplers/__init__.py
@@ -1,6 +1,7 @@
+from super_gradients.training.datasets.samplers.infinite_sampler import InfiniteSampler
 from super_gradients.training.datasets.samplers.repeated_augmentation_sampler import RepeatAugSampler
 from super_gradients.common.object_names import Samplers
 from super_gradients.common.registry.registry import SAMPLERS
 
 
-__all__ = ["SAMPLERS", "Samplers", "RepeatAugSampler"]
+__all__ = ["SAMPLERS", "Samplers", "InfiniteSampler", "RepeatAugSampler"]

--- a/src/super_gradients/training/datasets/samplers/infinite_sampler.py
+++ b/src/super_gradients/training/datasets/samplers/infinite_sampler.py
@@ -1,0 +1,13 @@
+from deprecated import deprecated
+from pyparsing import Optional
+from torch.utils.data import DistributedSampler, Dataset
+from super_gradients.common.registry.registry import register_sampler
+
+
+@register_sampler()
+class InfiniteSampler(DistributedSampler):
+    @deprecated(version="3.2.0", reason="InfiniteSampler is deprecated and will be removed in 3.2.0. Using equivalent " "DistributedSampler.")
+    def __init__(
+        self, dataset: Dataset, num_replicas: Optional[int] = None, rank: Optional[int] = None, shuffle: bool = True, seed: int = 0, drop_last: bool = False
+    ) -> None:
+        super(InfiniteSampler, self).__init__(dataset=dataset, num_replicas=num_replicas, rank=rank, shuffle=shuffle, seed=seed, drop_last=drop_last)

--- a/src/super_gradients/training/datasets/samplers/infinite_sampler.py
+++ b/src/super_gradients/training/datasets/samplers/infinite_sampler.py
@@ -1,5 +1,6 @@
+from typing import Optional
+
 from deprecated import deprecated
-from pyparsing import Optional
 from torch.utils.data import DistributedSampler, Dataset
 from super_gradients.common.registry.registry import register_sampler
 

--- a/src/super_gradients/training/models/__init__.py
+++ b/src/super_gradients/training/models/__init__.py
@@ -35,7 +35,7 @@ from super_gradients.training.models.classification_models.preact_resnet import 
     PreActResNet152,
 )
 from super_gradients.training.models.classification_models.resnet import (
-    Bottleneck,
+    Bottleneck as NewBottleneck,
     BasicResNetBlock,
     ResNet,
     ResNet18,
@@ -164,6 +164,16 @@ BasicBlock = make_deprecated(
     "[-] from super_gradients.training.models import BasicBlock\n"
     "[+] from super_gradients.training.models import BasicResNetBlock\n",
 )
+
+Bottleneck = make_deprecated(
+    func=NewBottleneck,
+    reason="You're importing `Bottleneck` class from `super_gradients.training.models`. This is deprecated since SuperGradients 3.1.0.\n"
+    "This block was renamed to BasicResNetBlock for better clarity.\n"
+    "Please update your code to import it as follows:\n"
+    "[-] from super_gradients.training.models import Bottleneck\n"
+    "[+] from super_gradients.training.models.classification_models.resnet import Bottleneck\n",
+)
+
 HpmStruct = make_deprecated(
     func=CurrVersionHpmStruct,
     reason="You're importing `HpmStruct` class from `super_gradients.training.models`. This is deprecated since SuperGradients 3.1.0.\n"

--- a/src/super_gradients/training/models/__init__.py
+++ b/src/super_gradients/training/models/__init__.py
@@ -35,6 +35,7 @@ from super_gradients.training.models.classification_models.preact_resnet import 
     PreActResNet152,
 )
 from super_gradients.training.models.classification_models.resnet import (
+    Bottleneck,
     BasicResNetBlock,
     ResNet,
     ResNet18,
@@ -132,7 +133,7 @@ from super_gradients.training.models.conversion import convert_to_coreml, conver
 from super_gradients.common.object_names import Models
 from super_gradients.common.registry.registry import ARCHITECTURES
 
-from super_gradients.training.utils import make_divisible as _make_divisible_current_version
+from super_gradients.training.utils import make_divisible as _make_divisible_current_version, HpmStruct as CurrVersionHpmStruct
 
 
 def make_deprecated(func, reason):
@@ -163,8 +164,18 @@ BasicBlock = make_deprecated(
     "[-] from super_gradients.training.models import BasicBlock\n"
     "[+] from super_gradients.training.models import BasicResNetBlock\n",
 )
+HpmStruct = make_deprecated(
+    func=CurrVersionHpmStruct,
+    reason="You're importing `HpmStruct` class from `super_gradients.training.models`. This is deprecated since SuperGradients 3.1.0.\n"
+    "Please update your code to import it as follows:\n"
+    "[-] from super_gradients.training.models import HpmStruct\n"
+    "[+] from super_gradients.training.utils import HpmStruct\n",
+)
+
 
 __all__ = [
+    "HpmStruct",
+    "Bottleneck",
     "SPP",
     "YoloNAS_S",
     "YoloNAS_M",

--- a/src/super_gradients/training/utils/optimizers/all_optimizers.py
+++ b/src/super_gradients/training/utils/optimizers/all_optimizers.py
@@ -6,5 +6,6 @@ OPTIMIZERS = CURRENT_VERSION_OPTIMIZERS
 
 warnings.warn(
     "super_gradients.training.utils.optimizers.all_opimitzers is deprecated in 3.1.1 and will be removed in 3.2.0.\n"
-    " To import OPTIMIZERS use: \n from super_gradients.common.registry.registry import OPTIMIZERS"
+    " To import OPTIMIZERS use: \n from super_gradients.common.registry.registry import OPTIMIZERS",
+    category=DeprecationWarning,
 )

--- a/src/super_gradients/training/utils/optimizers/all_optimizers.py
+++ b/src/super_gradients/training/utils/optimizers/all_optimizers.py
@@ -1,0 +1,10 @@
+import warnings
+
+from super_gradients.common.registry.registry import OPTIMIZERS as CURRENT_VERSION_OPTIMIZERS
+
+OPTIMIZERS = CURRENT_VERSION_OPTIMIZERS
+
+warnings.warn(
+    "super_gradients.training.utils.optimizers.all_opimitzers is deprecated in 3.1.1 and will be removed in 3.2.0.\n"
+    " To import OPTIMIZERS use: \n from super_gradients.common.registry.registry import OPTIMIZERS"
+)

--- a/src/super_gradients/training/utils/weight_averaging_utils.py
+++ b/src/super_gradients/training/utils/weight_averaging_utils.py
@@ -49,7 +49,7 @@ class ModelWeightAveraging:
             else:
                 averaging_snapshots_dict["snapshots_metric"] = np.inf * np.ones(self.number_of_models_to_average)
 
-        torch.save(averaging_snapshots_dict, self.averaging_snapshots_file)
+            torch.save(averaging_snapshots_dict, self.averaging_snapshots_file)
 
     def update_snapshots_dict(self, model, validation_results_tuple):
         """

--- a/tests/unit_tests/test_deprecations.py
+++ b/tests/unit_tests/test_deprecations.py
@@ -64,6 +64,29 @@ class DeprecationsUnitTest(unittest.TestCase):
         except ImportError:
             self.fail("ImportError raised unexpectedly for BasicBlock")
 
+    def test_moved_Bottleneck_import(self):
+        from super_gradients.training.models import Bottleneck as OldBottleneck  # noqa
+        from super_gradients.training.models.classification_models.resnet import Bottleneck
+
+        assert isinstance(Bottleneck(1, 1, 1), OldBottleneck)
+
+    def test_deprecated_optimizers_dict(self):
+        try:
+            with self.assertWarns(DeprecationWarning):
+                from super_gradients.training.utils.optimizers.all_optimizers import OPTIMIZERS  # noqa
+        except ImportError:
+            self.fail("ImportError raised unexpectedly for OPTIMIZERS")
+
+    def test_deprecated_HpmStruct_import(self):
+        try:
+            with self.assertWarns(DeprecationWarning):
+                from super_gradients.training.models import HpmStruct as OldHpmStruct
+                from super_gradients.training.utils import HpmStruct
+
+                assert isinstance(OldHpmStruct(a=1), HpmStruct)
+        except ImportError:
+            self.fail("ImportError raised unexpectedly for HpmStruct")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit_tests/test_deprecations.py
+++ b/tests/unit_tests/test_deprecations.py
@@ -65,10 +65,14 @@ class DeprecationsUnitTest(unittest.TestCase):
             self.fail("ImportError raised unexpectedly for BasicBlock")
 
     def test_moved_Bottleneck_import(self):
-        from super_gradients.training.models import Bottleneck as OldBottleneck  # noqa
-        from super_gradients.training.models.classification_models.resnet import Bottleneck
+        try:
+            with self.assertWarns(DeprecationWarning):
+                from super_gradients.training.models import Bottleneck as OldBottleneck  # noqa
+                from super_gradients.training.models.classification_models.resnet import Bottleneck
 
-        assert isinstance(Bottleneck(1, 1, 1), OldBottleneck)
+                assert isinstance(OldBottleneck(1, 1, 1), Bottleneck)
+        except ImportError:
+            self.fail("ImportError raised unexpectedly for Bottleneck")
 
     def test_deprecated_optimizers_dict(self):
         try:


### PR DESCRIPTION
Added deprecations, and backward compatibility to previous breaking changes.

In this PR:
- InfiniteSampler has been removed, added deprecation using equivalent DistributedSampler.
- Broken imports
`from super_gradients.training.utils.optimizers.all_optimizers import OPTIMIZERS`
`from super_gradients.training.models import BasicBlock, Bottleneck, HpmStruct`

- DDRNetCustom: the __init__ expected a parameter “aux_head” from “arch_params.aux_head”. In the new version of SG, this parameter is: “use_aux_heads=arch_params.use_aux_heads” - added deprecation.
- BasicDDRBackBone . In old SG version, this block didn’t expect layer3_repeats . Now SG expects it. Also, ddrnet model now assumes that “arch_params” has layer3_repeats parameter. Fixed by setting default=1.


Verified backward compatibility handled outside this PR:

Some were already handled in other PRs, this is the complete list + where they were handled:
- In `ema_params`, they had: `exp_activation: True`. Changed to `decay_type: exp` handled by @BloodAxe in 69a82bc4b82f0676210065606181de907affd5e9
- The architecture `custom_stdc` name was changed to `stdc_custom`. Handled by @ofrimasad in 190283ebcbf7a8a0feeb028d853c8492c0d3db85
- Broken import: `from super_gradients.training.models import make_divisible`, handled by @BloodAxe in 6b5785d9bb513c0bf0c126a63cc0eb2bf457b1a2
- Had: `trainer = Trainer(experiment_name=cfg.experiment_name, multi_gpu=cfg.multi_gpu)`. Changed to use `setup_device(()` instead - this is the only case where we throw an error, to avoid setting devices inside the Trainer. f50d438c35661b7f2ffea3130ae3b97e19ccc31a
- Models iinheriting from `CustomizableDetector` Used to call `super().__init__` only with `arch_params`. Now its changed to accept each parameter separately:
```
super().__init__(
    backbone=arch_params.backbone,
    heads=arch_params.heads,
    neck=arch_params.neck,
    num_classes=arch_params.num_classes,
    bn_eps=arch_params.bn_eps,
    bn_momentum=arch_params.bn_momentum,
    inplace_act=arch_params.inplace_act
)

```
handled by @Louis-Dupont  in a3618e87b105808729576408fbcb878441696bc7

