### PR TITLE
Allow checkpoint_path to be an url (Required for transfer learning)

### DIFF
--- a/src/super_gradients/training/models/model_factory.py
+++ b/src/super_gradients/training/models/model_factory.py
@@ -177,7 +177,7 @@ def get(
                                     If None is given, will try to derrive from pretrained_weight's corresponding dataset.
     :param strict_load:         See super_gradients.common.data_types.enum.strict_load.StrictLoad class documentation for details
                                     (default=NO_KEY_MATCHING to suport SG trained checkpoints)
-    :param checkpoint_path:     The path to the external checkpoint to be loaded. Can be absolute or relative (ie: path/to/checkpoint.pth).
+    :param checkpoint_path:     The path to the external checkpoint to be loaded. Can be absolute or relative (ie: path/to/checkpoint.pth) path or URL.
                                     If provided, will automatically attempt to load the checkpoint.
     :param pretrained_weights:  Describe the dataset of the pretrained weights (for example "imagenent").
     :param load_backbone:       Load the provided checkpoint to model.backbone instead of model.

--- a/src/super_gradients/training/utils/checkpoint_utils.py
+++ b/src/super_gradients/training/utils/checkpoint_utils.py
@@ -10,6 +10,7 @@ from super_gradients.common.decorators.explicit_params_validator import explicit
 from super_gradients.module_interfaces import HasPredict
 from super_gradients.training.pretrained_models import MODEL_URLS
 from super_gradients.common.data_types import StrictLoad
+from super_gradients.training.utils.distributed_training_utils import get_local_rank, wait_for_the_master
 
 from torch import nn, Tensor
 from typing import Union, Mapping
@@ -120,21 +121,31 @@ def copy_ckpt_to_local_folder(
     if path_src == "url":
         ckpt_file_full_local_path = download_ckpt_destination_dir + os.path.sep + ckpt_filename
         # DOWNLOAD THE FILE FROM URL TO THE DESTINATION FOLDER
-        download_url_to_file(remote_ckpt_source_dir, ckpt_file_full_local_path, progress=True)
+        with wait_for_the_master(get_local_rank()):
+            download_url_to_file(remote_ckpt_source_dir, ckpt_file_full_local_path, progress=True)
 
     return ckpt_file_full_local_path
 
 
-def read_ckpt_state_dict(ckpt_path: str, device="cpu"):
-    if not os.path.exists(ckpt_path):
-        raise FileNotFoundError(f"Incorrect Checkpoint path: {ckpt_path} (This should be an absolute path)")
+def read_ckpt_state_dict(ckpt_path: str, device="cpu") -> collections.OrderedDict[str, torch.Tensor]:
+    """
+    Reads a checkpoint state dict from a given path or url
 
-    if device == "cuda":
-        state_dict = torch.load(ckpt_path)
+    :param ckpt_path: Checkpoint path or url
+    :param device: Target devide where tensors should be loaded
+    :return: Checkpoint state dict object
+    """
 
+    if ckpt_path.startswith("https://"):
+        with wait_for_the_master(get_local_rank()):
+            state_dict = load_state_dict_from_url(ckpt_path, progress=False, map_location=device)
+        return state_dict
     else:
-        state_dict = torch.load(ckpt_path, map_location=lambda storage, loc: storage)
-    return state_dict
+        if not os.path.exists(ckpt_path):
+            raise FileNotFoundError(f"Incorrect Checkpoint path: {ckpt_path} (This should be an absolute path)")
+
+        state_dict = torch.load(ckpt_path, map_location=device)
+        return state_dict
 
 
 def adapt_state_dict_to_fit_model_layer_names(model_state_dict: dict, source_ckpt: dict, exclude: list = [], solver: callable = None):
@@ -205,10 +216,6 @@ def load_checkpoint_to_model(
     """
     if isinstance(strict, str):
         strict = StrictLoad(strict)
-
-    if ckpt_local_path is None or not os.path.exists(ckpt_local_path):
-        error_msg = "Error - loading Model Checkpoint: Path {} does not exist".format(ckpt_local_path)
-        raise RuntimeError(error_msg)
 
     if load_backbone and not hasattr(net, "backbone"):
         raise ValueError("No backbone attribute in net - Can't load backbone weights")
@@ -308,7 +315,8 @@ def load_pretrained_weights(model: torch.nn.Module, architecture: str, pretraine
 
     unique_filename = url.split("https://sghub.deci.ai/models/")[1].replace("/", "_").replace(" ", "_")
     map_location = torch.device("cpu")
-    pretrained_state_dict = load_state_dict_from_url(url=url, map_location=map_location, file_name=unique_filename)
+    with wait_for_the_master(get_local_rank()):
+        pretrained_state_dict = load_state_dict_from_url(url=url, map_location=map_location, file_name=unique_filename)
     _load_weights(architecture, model, pretrained_state_dict)
 
 

--- a/tests/unit_tests/load_checkpoint_test.py
+++ b/tests/unit_tests/load_checkpoint_test.py
@@ -3,6 +3,8 @@ import unittest
 import torch.nn.init
 from torch import nn
 
+from super_gradients.common.object_names import Models
+from super_gradients.training import models
 from super_gradients.training.utils.checkpoint_utils import transfer_weights
 
 
@@ -29,3 +31,12 @@ class LoadCheckpointTest(unittest.TestCase):
         self.assertFalse((foo.fc2.weight == bar.fc2.weight).all())
         transfer_weights(foo, bar.state_dict())
         self.assertTrue((foo.fc2.weight == bar.fc2.weight).all())
+
+    def test_checkpoint_path_url(self):
+        m1 = models.get(Models.YOLO_NAS_S, num_classes=80, checkpoint_path="https://sghub.deci.ai/models/yolo_nas_s_coco.pth")
+        m2 = models.get(Models.YOLO_NAS_S, pretrained_weights="coco")
+        m1_state = m1.state_dict()
+        m2_state = m2.state_dict()
+        self.assertTrue(m1_state.keys() == m2_state.keys())
+        for k in m1_state.keys():
+            self.assertTrue((m1_state[k] == m2_state[k]).all())


### PR DESCRIPTION
- Allow checkpoint_path to be an url (Required for transfer learning)
- Added synchronization primitives to prevent race conditions when downloading weights

One can now load checkpoints like so:
```
models.get(Models.YOLO_NAS_S, num_classes=80, checkpoint_path="https://sghub.deci.ai/models/yolo_nas_s_coco.pth")
```

Why we want this to have: For training YOLO-NAS-POSE we want to use YOLO-NAS-OD pretrained weights like so:
```
checkpoint_params:
  checkpoint_path: "https://sghub.deci.ai/models/yolo_nas_s_coco.pth"
```

This PR enables us to do this.
