### PR TITLE
Allow passing tuple of [low, high] to iou_thresholds parameter in DetectionMetrics.

### DIFF
--- a/src/super_gradients/training/metrics/detection_metrics.py
+++ b/src/super_gradients/training/metrics/detection_metrics.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, Tuple
 import torch
 from torchmetrics import Metric
 
@@ -24,6 +24,7 @@ class DetectionMetrics(Metric):
     :param post_prediction_callback:        DetectionPostPredictionCallback to be applied on net's output prior to the metric computation (NMS).
     :param normalize_targets:               Whether to normalize bbox coordinates by image size.
     :param iou_thres:                       IoU threshold to compute the mAP.
+                                            Could be either instance of IouThreshold, a tuple (lower bound, upper_bound) or single scalar.
     :param recall_thres:                    Recall threshold to compute the mAP.
     :param score_thres:                     Score threshold to compute Recall, Precision and F1.
     :param top_k_predictions:               Number of predictions per class used to compute metrics, ordered by confidence score
@@ -37,7 +38,7 @@ class DetectionMetrics(Metric):
         num_cls: int,
         post_prediction_callback: DetectionPostPredictionCallback,
         normalize_targets: bool = False,
-        iou_thres: Union[IouThreshold, float] = IouThreshold.MAP_05_TO_095,
+        iou_thres: Union[IouThreshold, Tuple[float, float], float] = IouThreshold.MAP_05_TO_095,
         recall_thres: torch.Tensor = None,
         score_thres: float = 0.1,
         top_k_predictions: int = 100,
@@ -50,6 +51,9 @@ class DetectionMetrics(Metric):
 
         if isinstance(iou_thres, IouThreshold):
             self.iou_thresholds = iou_thres.to_tensor()
+        if isinstance(iou_thres, tuple):
+            low, high = iou_thres
+            self.iou_thresholds = IouThreshold.from_bounds(low, high)
         else:
             self.iou_thresholds = torch.tensor([iou_thres])
 

--- a/src/super_gradients/training/utils/detection_utils.py
+++ b/src/super_gradients/training/utils/detection_utils.py
@@ -208,7 +208,14 @@ class IouThreshold(tuple, Enum):
             return torch.tensor([self[0]])
 
     @classmethod
-    def from_bounds(cls, low, high, step=0.05):
+    def from_bounds(cls, low: float, high: float, step: float = 0.05) -> torch.Tensor:
+        """
+        Create a tensor with values from low (including) to high (including) with a given step size.
+        :param low: Lower bound
+        :param high: Upper bound
+        :param step: Step size
+        :return: Tensor of [low, low + step, low + 2 * step, ..., high]
+        """
         n_iou_thresh = int(round((high - low) / step)) + 1
         return torch.linspace(low, high, n_iou_thresh)
 

--- a/src/super_gradients/training/utils/detection_utils.py
+++ b/src/super_gradients/training/utils/detection_utils.py
@@ -203,11 +203,14 @@ class IouThreshold(tuple, Enum):
 
     def to_tensor(self):
         if self.is_range():
-            n_iou_thresh = int(round((self[1] - self[0]) / 0.05)) + 1
-            return torch.linspace(self[0], self[1], n_iou_thresh)
+            return self.from_bounds(self[0], self[1], step=0.05)
         else:
-            n_iou_thresh = 1
             return torch.tensor([self[0]])
+
+    @classmethod
+    def from_bounds(cls, low, high, step=0.05):
+        n_iou_thresh = int(round((high - low) / step)) + 1
+        return torch.linspace(low, high, n_iou_thresh)
 
 
 def box_iou(box1: torch.Tensor, box2: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
This PR allows to pass user-defined target of IoU thresholds without asking user to edit IoUThresholds enum in SG codebase:

```
valid_metrics_list:
  - DetectionMetrics:
      iou_thres: [0.5, 0.8]
```

Note that this does not solve the problem of having two instances of `DetectionMetrics` in `valid_metrics_list`, but it allow to pass iou_thres as a tuple which we do not allow at the moment