### PR TITLE
Fix datasetparams not showing

### DIFF
--- a/src/super_gradients/training/dataloaders/dataloaders.py
+++ b/src/super_gradients/training/dataloaders/dataloaders.py
@@ -887,6 +887,11 @@ def get(name: str = None, dataset_params: Dict = None, dataloader_params: Dict =
     if dataset is not None:
         dataloader_params = _process_sampler_params(dataloader_params, dataset, {})
         dataloader = DataLoader(dataset=dataset, **dataloader_params)
+
+        dataloader.dataloader_params = dataloader_params
+        if not hasattr(dataset, "dataset_params"):
+            dataset.dataset_params = dataset_params
+
     elif name not in ALL_DATALOADERS.keys():
         raise ValueError("Unsupported dataloader: " + str(name))
     else:


### PR DESCRIPTION
### Background
When someone defines the dataset name from `dataloader_params`, the parameters are not properly logged

```yaml
val_dataloader_params:
  dataset: Cifar10
  batch_size: 512
  num_workers: 8
  drop_last: False
  pin_memory: True
```

![image](https://github.com/Deci-AI/super-gradients/assets/35190946/02ae4709-8fa9-4bfe-b623-21df1e16b0de)
