### PR TITLE
Feature/sg 1059 fix ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             python3 -m pip install pip==23.1.2
-            cat requirements.txt | cut -f1 -d"#" | xargs -n 1 -L 1 pip install --progress-bar off
+            python3 -m pip install -r requirements.txt
       - run:
           name: edit package version
           command: |
@@ -189,7 +189,6 @@ jobs:
       - run:
           name: setup custom environment variables
           command: |
-            # echo 'export PYTHONPATH=/home/circleci/super_gradients' >> $BASH_ENV
             echo 'export UPLOAD_LOGS=FALSE' >> $BASH_ENV
       - run:
           name: install package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,14 +189,23 @@ jobs:
       - run:
           name: setup custom environment variables
           command: |
-            echo 'export PYTHONPATH=/home/circleci/super_gradients' >> $BASH_ENV
+            # echo 'export PYTHONPATH=/home/circleci/super_gradients' >> $BASH_ENV
             echo 'export UPLOAD_LOGS=FALSE' >> $BASH_ENV
       - run:
           name: install package
           no_output_timeout: 30m
           command: |
             . venv/bin/activate
-            python3 -m pip install --extra-index-url https://pypi.ngc.nvidia.com .[pro]
+            python3 -m pip uninstall -y super_gradients
+            python3 -m pip install -e .[pro] --extra-index-url https://pypi.ngc.nvidia.com
+
+      - run:
+          name: install pytorch quantization package
+          no_output_timeout: 30m
+          command: |
+            . venv/bin/activate
+            python3 -m pip install pytorch-quantization==2.1.2 --extra-index-url https://pypi.ngc.nvidia.com
+
       - run:
           name: run tests with coverage
           no_output_timeout: 30m

--- a/src/super_gradients/sanity_check/env_sanity_check.py
+++ b/src/super_gradients/sanity_check/env_sanity_check.py
@@ -68,7 +68,9 @@ def get_requirements(use_pro_requirements: bool) -> Optional[List[str]]:
     with open(pro_requirements_path, "r") as f:
         pro_requirements = f.read().splitlines()
 
-    return requirements + pro_requirements if use_pro_requirements else requirements
+    lines = requirements + pro_requirements if use_pro_requirements else requirements
+    lines = [line for line in lines if not line.startswith("--extra-index-url")]  # Remove index-url lines
+    return lines
 
 
 def check_packages():


### PR DESCRIPTION
# What this PR does

Ensures that we test againts a checkout copy of SG. 
It first uninstall the (maybe) existing SG installation and do a development-install a checkouted copy.
This PR also adds an option to have `--extra-index-url` in requirements.txt (Would be necessary for export API PR)
Since we install the SG we also remove the unnecessary `export PYTHONPATH=/home/circleci/super_gradients`
