### PR TITLE
BaseKeypointsDataset now inherits from HasPreprocessingParams

### DIFF
--- a/src/super_gradients/module_interfaces/module_interfaces.py
+++ b/src/super_gradients/module_interfaces/module_interfaces.py
@@ -1,13 +1,13 @@
-from typing import Callable, Optional
+from typing import Callable, Optional, TYPE_CHECKING
 
 from torch import nn
-from typing_extensions import Protocol, runtime_checkable
 
-from super_gradients.training.processing.processing import Processing
+if TYPE_CHECKING:
+    # This is a hack to avoid circular imports while still having type hints.
+    from super_gradients.training.processing.processing import Processing
 
 
-@runtime_checkable
-class HasPreprocessingParams(Protocol):
+class HasPreprocessingParams:
     """
     Protocol interface for torch datasets that support getting preprocessing params, later to be passed to a model
     that obeys NeedsPreprocessingParams. This interface class serves a purpose of explicitly indicating whether a torch dataset has
@@ -16,7 +16,7 @@ class HasPreprocessingParams(Protocol):
     """
 
     def get_dataset_preprocessing_params(self):
-        ...
+        raise NotImplementedError(f"get_dataset_preprocessing_params is not implemented in the derived class {self.__class__.__name__}")
 
 
 class HasPredict:
@@ -43,12 +43,11 @@ class HasPredict:
         """
         raise NotImplementedError(f"get_input_channels is not implemented in the derived class {self.__class__.__name__}")
 
-    def get_processing_params(self) -> Optional[Processing]:
+    def get_processing_params(self) -> Optional["Processing"]:
         raise NotImplementedError(f"get_processing_params is not implemented in the derived class {self.__class__.__name__}")
 
 
-@runtime_checkable
-class SupportsReplaceNumClasses(Protocol):
+class SupportsReplaceNumClasses:
     """
     Protocol interface for modules that support replacing the number of classes.
     Derived classes should implement the `replace_num_classes` method.
@@ -69,4 +68,4 @@ class SupportsReplaceNumClasses(Protocol):
             It takes existing nn.Module and returns a new one.
         :return: None
         """
-        ...
+        raise NotImplementedError(f"replace_num_classes is not implemented in the derived class {self.__class__.__name__}")

--- a/src/super_gradients/training/datasets/detection_datasets/detection_dataset.py
+++ b/src/super_gradients/training/datasets/detection_datasets/detection_dataset.py
@@ -16,6 +16,7 @@ from torch.utils.data import Dataset
 from super_gradients.common.object_names import Datasets, Processings
 from super_gradients.common.registry.registry import register_dataset
 from super_gradients.common.decorators.factory_decorator import resolve_param
+from super_gradients.module_interfaces import HasPreprocessingParams
 from super_gradients.training.utils.detection_utils import get_class_index_in_target
 from super_gradients.common.abstractions.abstract_logger import get_logger
 from super_gradients.training.transforms.transforms import DetectionTransform, DetectionTargetsFormatTransform, DetectionTargetsFormat
@@ -30,7 +31,7 @@ logger = get_logger(__name__)
 
 
 @register_dataset(Datasets.DETECTION_DATASET)
-class DetectionDataset(Dataset):
+class DetectionDataset(Dataset, HasPreprocessingParams):
     """Detection dataset.
 
     This is a boilerplate class to facilitate the implementation of datasets.

--- a/src/super_gradients/training/datasets/pose_estimation_datasets/base_keypoints.py
+++ b/src/super_gradients/training/datasets/pose_estimation_datasets/base_keypoints.py
@@ -8,6 +8,7 @@ from torch.utils.data.dataloader import default_collate, Dataset
 from super_gradients.common.abstractions.abstract_logger import get_logger
 from super_gradients.common.object_names import Processings
 from super_gradients.common.registry.registry import register_collate_function
+from super_gradients.module_interfaces import HasPreprocessingParams
 from super_gradients.training.datasets.pose_estimation_datasets.target_generators import KeypointsTargetsGenerator
 from super_gradients.training.transforms.keypoint_transforms import KeypointsCompose, KeypointTransform
 from super_gradients.training.utils.visualization.utils import generate_color_mapping
@@ -15,7 +16,7 @@ from super_gradients.training.utils.visualization.utils import generate_color_ma
 logger = get_logger(__name__)
 
 
-class BaseKeypointsDataset(Dataset):
+class BaseKeypointsDataset(Dataset, HasPreprocessingParams):
     """
     Base class for pose estimation datasets.
     Descendants should implement the load_sample method to read a sample from the disk and return (image, mask, joints, extras) tuple.
@@ -116,7 +117,7 @@ class BaseKeypointsDataset(Dataset):
         """
         pipeline = self.transforms.get_equivalent_preprocessing()
         params = dict(
-            conf=0.25,
+            conf=0.05,
             image_processor={Processings.ComposeProcessing: {"processings": pipeline}},
             edge_links=self.edge_links,
             edge_colors=self.edge_colors,

--- a/src/super_gradients/training/datasets/pose_estimation_datasets/coco_keypoints.py
+++ b/src/super_gradients/training/datasets/pose_estimation_datasets/coco_keypoints.py
@@ -216,7 +216,7 @@ class COCOKeypointsDataset(BaseKeypointsDataset):
         # to match with the expected input of the model.
         pipeline = [Processings.ReverseImageChannels] + self.transforms.get_equivalent_preprocessing()
         params = dict(
-            conf=0.25,
+            conf=0.05,
             image_processor={Processings.ComposeProcessing: {"processings": pipeline}},
             edge_links=self.edge_links,
             edge_colors=self.edge_colors,

--- a/tests/unit_tests/preprocessing_unit_test.py
+++ b/tests/unit_tests/preprocessing_unit_test.py
@@ -86,11 +86,11 @@ class PreprocessingUnitTest(unittest.TestCase):
             ],
         }
         trainset = COCODetectionDataset(**train_dataset_params)
-        assert isinstance(trainset, HasPreprocessingParams)
+        self.assertIsInstance(trainset, HasPreprocessingParams)
         train_loader = dataloaders.get(dataset=trainset, dataloader_params={"collate_fn": DetectionCollateFN(), "num_workers": 0})
 
         valset = COCODetectionDataset(**val_dataset_params)
-        assert isinstance(valset, HasPreprocessingParams)
+        self.assertIsInstance(valset, HasPreprocessingParams)
         valid_loader = dataloaders.get(dataset=valset, dataloader_params={"collate_fn": CrowdDetectionCollateFN(), "num_workers": 0})
 
         trainer = Trainer("test_setting_preprocessing_params_from_validation_set")


### PR DESCRIPTION
# Bugfixes 

* BaseKeypointsDataset now inherits from HasPreprocessingParams to ensure preprocessing params for pose estimation model are saved properly.
* Changed default confidence threshold from 0.25 to 0.05 to match the default confidence threshold as is training recipe.

# Improvement
SupportsReplaceNumClasses and HasPreprocessingParams are no Protocols anymore.
Motivation:

A Protocol class seems to do a lot of black vodoo magic:

```python
class HasPreprocessingParams(Protocol):
   ...

class DetectionDataset(Dataset): # No HasPreprocessingParams
   ...

class COCODetectionDataset(DetectionDataset)

dataset = COCODetectionDataset(...)
isinstance(dataset, HasPreprocessingParams) # Returns True :exploding_head: 
```

Even not inheriting from HasPreprocessingParams but having the methods with matching signature implement, the isinstance returns True. Which may be really undesired/unexpected/coincidence.
