### PR TITLE
Fix Breaking Change Detection on Inheritence

### DIFF
--- a/tests/breaking_change_tests/unit_test.py
+++ b/tests/breaking_change_tests/unit_test.py
@@ -226,7 +226,7 @@ class TestBreakingChangeDetection(unittest.TestCase):
         self.assertEqual(len(breaking_changes.functions_removed), 1)
         self.assertEqual(breaking_changes.functions_removed[0].function_name, "MyClass.method")
 
-    def test_inheritance(self):
+    def test_inheritance_detection(self):
         code = """
 class Base1:
     def method_in_base1(self): pass
@@ -255,6 +255,13 @@ class Derived(Base1, Base2):
             ),
         }
         self.assertEqual(parse_functions_signatures(code), expected)
+
+    def test_inheritance_breaking_change(self):
+        old_code = "class MyClass:\n    def method(self): pass"
+        new_code = "class MyNewClass:\n    def method(self): pass\nclass MyClass(MyNewClass): pass"  # MyClass.method() will still work
+
+        breaking_changes = extract_code_breaking_changes("module.py", old_code, new_code)
+        self.assertEqual(len(breaking_changes.functions_removed), 0)
 
 
 if __name__ == "__main__":

--- a/tests/breaking_change_tests/unit_test.py
+++ b/tests/breaking_change_tests/unit_test.py
@@ -226,6 +226,36 @@ class TestBreakingChangeDetection(unittest.TestCase):
         self.assertEqual(len(breaking_changes.functions_removed), 1)
         self.assertEqual(breaking_changes.functions_removed[0].function_name, "MyClass.method")
 
+    def test_inheritance(self):
+        code = """
+class Base1:
+    def method_in_base1(self): pass
+
+class Base2:
+    def method_in_base2(self): pass
+
+class Derived(Base1, Base2):
+    def method_in_derived(self): pass
+"""
+        expected = {
+            "Base1.method_in_base1": FunctionSignature(
+                name="Base1.method_in_base1", line_num=3, params=FunctionParameters([FunctionParameter(name="self", has_default=False)])
+            ),
+            "Base2.method_in_base2": FunctionSignature(
+                name="Base2.method_in_base2", line_num=6, params=FunctionParameters([FunctionParameter(name="self", has_default=False)])
+            ),
+            "Derived.method_in_base1": FunctionSignature(
+                name="Derived.method_in_base1", line_num=3, params=FunctionParameters([FunctionParameter(name="self", has_default=False)])
+            ),
+            "Derived.method_in_base2": FunctionSignature(
+                name="Derived.method_in_base2", line_num=6, params=FunctionParameters([FunctionParameter(name="self", has_default=False)])
+            ),
+            "Derived.method_in_derived": FunctionSignature(
+                name="Derived.method_in_derived", line_num=9, params=FunctionParameters([FunctionParameter(name="self", has_default=False)])
+            ),
+        }
+        self.assertEqual(parse_functions_signatures(code), expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/breaking_change_tests/unit_test.py
+++ b/tests/breaking_change_tests/unit_test.py
@@ -236,6 +236,9 @@ class Base2:
 
 class Derived(Base1, Base2):
     def method_in_derived(self): pass
+
+class DerivedChild(Derived):
+    def method_in_derived_child(self): pass
 """
         expected = {
             "Base1.method_in_base1": FunctionSignature(
@@ -252,6 +255,18 @@ class Derived(Base1, Base2):
             ),
             "Derived.method_in_derived": FunctionSignature(
                 name="Derived.method_in_derived", line_num=9, params=FunctionParameters([FunctionParameter(name="self", has_default=False)])
+            ),
+            "DerivedChild.method_in_base1": FunctionSignature(
+                name="DerivedChild.method_in_base1", line_num=3, params=FunctionParameters([FunctionParameter(name="self", has_default=False)])
+            ),
+            "DerivedChild.method_in_base2": FunctionSignature(
+                name="DerivedChild.method_in_base2", line_num=6, params=FunctionParameters([FunctionParameter(name="self", has_default=False)])
+            ),
+            "DerivedChild.method_in_derived": FunctionSignature(
+                name="DerivedChild.method_in_derived", line_num=9, params=FunctionParameters([FunctionParameter(name="self", has_default=False)])
+            ),
+            "DerivedChild.method_in_derived_child": FunctionSignature(
+                name="DerivedChild.method_in_derived_child", line_num=12, params=FunctionParameters([FunctionParameter(name="self", has_default=False)])
             ),
         }
         self.assertEqual(parse_functions_signatures(code), expected)


### PR DESCRIPTION
### Context
Let's imagine we change the code

FROM
```python
class MyClass:
    def method(self): pass
```

TO
```python
class MyNewClass:
    def method(self): pass

class MyClass(MyNewClass): pass
```

This is **NOT** a breaking change, because `MyClass` inherits from `MyNewClass` which still includes `method`.

**Issue**: current class signature extractor (implemented as part of the breaking change detection) currently misses this and will raise that the new `MyClass` does not include `method`.