### PR TITLE
Remove __target__ for Detection CollateFN

### DIFF
--- a/documentation/source/ObjectDetection.md
+++ b/documentation/source/ObjectDetection.md
@@ -500,8 +500,7 @@ train_dataloader_params:
   worker_init_fn:
     _target_: super_gradients.training.utils.utils.load_func
     dotpath: super_gradients.training.datasets.datasets_utils.worker_init_reset_seed
-  collate_fn:
-    _target_: super_gradients.training.utils.detection_utils.DetectionCollateFN
+  collate_fn: DetectionCollateFN
 
 val_dataset_params:
   data_dir: ${dataset_params.root_dir}
@@ -521,8 +520,7 @@ val_dataloader_params:
   num_workers: 8
   drop_last: True
   pin_memory: True
-  collate_fn:
-    _target_: super_gradients.training.utils.detection_utils.DetectionCollateFN
+  collate_fn: DetectionCollateFN
 ```
 
 In your training recipe add/change the following lines to:

--- a/src/super_gradients/recipes/dataset_params/coco_detection_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/coco_detection_dataset_params.yaml
@@ -52,8 +52,7 @@ train_dataloader_params:
   worker_init_fn:
     _target_: super_gradients.training.utils.utils.load_func
     dotpath: super_gradients.training.datasets.datasets_utils.worker_init_reset_seed
-  collate_fn: # collate function for trainset
-    _target_: super_gradients.training.utils.detection_utils.DetectionCollateFN
+  collate_fn: DetectionCollateFN
 
 val_dataset_params:
   data_dir: /data/coco # root path to coco data
@@ -80,8 +79,7 @@ val_dataloader_params:
   num_workers: 8
   drop_last: False
   pin_memory: True
-  collate_fn: # collate function for valset
-    _target_: super_gradients.training.utils.detection_utils.CrowdDetectionCollateFN
+  collate_fn: CrowdDetectionCollateFN
 
 
 _convert_: all

--- a/src/super_gradients/recipes/dataset_params/coco_detection_ppyoloe_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/coco_detection_ppyoloe_dataset_params.yaml
@@ -55,15 +55,15 @@ train_dataloader_params:
   worker_init_fn:
     _target_: super_gradients.training.utils.utils.load_func
     dotpath: super_gradients.training.datasets.datasets_utils.worker_init_reset_seed
-  collate_fn: # collate function for trainset
-    _target_: super_gradients.training.utils.detection_utils.PPYoloECollateFN
-    random_resize_sizes: [ 320, 352, 384, 416, 448, 480, 512, 544, 576, 608, 640, 672, 704, 736, 768 ]
-    random_resize_modes:
-      - 0 # cv::INTER_NEAREST
-      - 1 # cv::INTER_LINEAR
-      - 2 # cv::INTER_CUBIC
-      - 3 # cv::INTER_AREA
-      - 4 # cv::INTER_LANCZOS4
+  collate_fn:
+    PPYoloECollateFN:
+      random_resize_sizes: [ 320, 352, 384, 416, 448, 480, 512, 544, 576, 608, 640, 672, 704, 736, 768 ]
+      random_resize_modes:
+        - 0 # cv::INTER_NEAREST
+        - 1 # cv::INTER_LINEAR
+        - 2 # cv::INTER_CUBIC
+        - 3 # cv::INTER_AREA
+        - 4 # cv::INTER_LANCZOS4
 
 val_dataset_params:
   data_dir: /data/coco # root path to coco data
@@ -93,7 +93,6 @@ val_dataloader_params:
   drop_last: False
   shuffle: False
   pin_memory: False
-  collate_fn: # collate function for valset
-    _target_: super_gradients.training.utils.detection_utils.CrowdDetectionPPYoloECollateFN
+  collate_fn: CrowdDetectionPPYoloECollateFN
 
 _convert_: all

--- a/src/super_gradients/recipes/dataset_params/coco_detection_ssd_lite_mobilenet_v2_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/coco_detection_ssd_lite_mobilenet_v2_dataset_params.yaml
@@ -48,8 +48,7 @@ train_dataloader_params:
   worker_init_fn:
     _target_: super_gradients.training.utils.utils.load_func
     dotpath: super_gradients.training.datasets.datasets_utils.worker_init_reset_seed
-  collate_fn: # collate function for trainset
-    _target_: super_gradients.training.utils.detection_utils.DetectionCollateFN
+  collate_fn: DetectionCollateFN
 
 val_dataset_params:
   data_dir: /data/coco # root path to coco data
@@ -76,7 +75,6 @@ val_dataloader_params:
   num_workers: 8
   drop_last: False
   pin_memory: True
-  collate_fn: # collate function for valset
-    _target_: super_gradients.training.utils.detection_utils.CrowdDetectionCollateFN
+  collate_fn: CrowdDetectionCollateFN
 
 _convert_: all

--- a/src/super_gradients/recipes/dataset_params/coco_detection_yolo_format_base_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/coco_detection_yolo_format_base_dataset_params.yaml
@@ -55,8 +55,7 @@ train_dataloader_params:
   shuffle: True
   drop_last: True
   pin_memory: True
-  collate_fn:
-    _target_: super_gradients.training.utils.detection_utils.DetectionCollateFN
+  collate_fn: DetectionCollateFN
 
 val_dataset_params:
   data_dir: /data/coco # TO FILL: Where the data is stored.
@@ -88,7 +87,6 @@ val_dataloader_params:
   num_workers: 8
   drop_last: False
   pin_memory: True
-  collate_fn:
-    _target_: super_gradients.training.utils.detection_utils.DetectionCollateFN
+  collate_fn: DetectionCollateFN
 
 _convert_: all

--- a/src/super_gradients/recipes/dataset_params/coco_detection_yolo_nas_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/coco_detection_yolo_nas_dataset_params.yaml
@@ -51,8 +51,7 @@ train_dataloader_params:
   shuffle: True
   drop_last: True
   pin_memory: True
-  collate_fn:
-    _target_: super_gradients.training.utils.detection_utils.DetectionCollateFN
+  collate_fn: DetectionCollateFN
 
 val_dataset_params:
   data_dir: /data/coco # root path to coco data
@@ -86,7 +85,6 @@ val_dataloader_params:
   drop_last: False
   shuffle: False
   pin_memory: True
-  collate_fn:
-    _target_: super_gradients.training.utils.detection_utils.CrowdDetectionCollateFN
+  collate_fn: CrowdDetectionCollateFN
 
 _convert_: all

--- a/src/super_gradients/recipes/dataset_params/pascal_voc_detection_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/pascal_voc_detection_dataset_params.yaml
@@ -39,16 +39,14 @@ train_dataloader_params:
   worker_init_fn:
     _target_: super_gradients.training.utils.utils.load_func
     dotpath: super_gradients.training.datasets.datasets_utils.worker_init_reset_seed
-  collate_fn: # collate function for trainset
-    _target_: super_gradients.training.utils.detection_utils.DetectionCollateFN
+  collate_fn: DetectionCollateFN
 
 val_dataloader_params:
   batch_size: 64
   num_workers: 8
   drop_last: False
   pin_memory: True
-  collate_fn: # collate function for trainset
-    _target_: super_gradients.training.utils.detection_utils.DetectionCollateFN
+  collate_fn: DetectionCollateFN
 
 
 _convert_: all

--- a/src/super_gradients/recipes/dataset_params/roboflow_detection_dataset_params.yaml
+++ b/src/super_gradients/recipes/dataset_params/roboflow_detection_dataset_params.yaml
@@ -61,8 +61,7 @@ train_dataloader_params:
   worker_init_fn:
     _target_: super_gradients.training.utils.utils.load_func
     dotpath: super_gradients.training.datasets.datasets_utils.worker_init_reset_seed
-  collate_fn: # collate function for trainset
-    _target_: super_gradients.training.utils.detection_utils.DetectionCollateFN
+  collate_fn: DetectionCollateFN
 
 val_dataset_params:
   data_dir: ${..data_dir} # root path to Robflow datasets
@@ -94,8 +93,7 @@ val_dataloader_params:
   drop_last: False
   shuffle: False
   pin_memory: True
-  collate_fn: # collate function for valset
-    _target_: super_gradients.training.utils.detection_utils.CrowdDetectionCollateFN
+  collate_fn: CrowdDetectionCollateFN
 
 
 _convert_: all

--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -11,7 +11,8 @@ import torch.cuda
 import torch.nn
 import torchmetrics
 from omegaconf import DictConfig, OmegaConf
-from piptools.scripts.sync import _get_installed_distributions
+
+# from piptools.scripts.sync import _get_installed_distributions
 from torch import nn
 from torch.cuda.amp import GradScaler, autocast
 from torch.utils.data import DataLoader, SequentialSampler
@@ -1869,8 +1870,8 @@ class Trainer:
         }
         # ADD INSTALLED PACKAGE LIST + THEIR VERSIONS
         if self.training_params.log_installed_packages:
-            pkg_list = list(map(lambda pkg: str(pkg), _get_installed_distributions()))
-            additional_log_items["installed_packages"] = pkg_list
+            # pkg_list = list(map(lambda pkg: str(pkg), _get_installed_distributions()))
+            additional_log_items["installed_packages"] = []
 
         dataset_params = {
             "train_dataset_params": self.train_loader.dataset.dataset_params if hasattr(self.train_loader.dataset, "dataset_params") else None,


### PR DESCRIPTION
Motivation:
- No reason to use `__target__` when we actually already register these objects

Why now ?
- In another branch, want to move the collate_fn to another module (I'll add deprecated to not break anything). Removing the absolute path of `__target__` in favor of Factory will make the PR look much simpler.