### PR TITLE
A call to _process_collate_fn_params was missing in dataloaders.get. …

### DIFF
--- a/src/super_gradients/training/dataloaders/dataloaders.py
+++ b/src/super_gradients/training/dataloaders/dataloaders.py
@@ -886,6 +886,8 @@ def get(name: str = None, dataset_params: Dict = None, dataloader_params: Dict =
 
     if dataset is not None:
         dataloader_params = _process_sampler_params(dataloader_params, dataset, {})
+        dataloader_params = _process_collate_fn_params(dataloader_params)
+
         dataloader = DataLoader(dataset=dataset, **dataloader_params)
 
         dataloader.dataloader_params = dataloader_params


### PR DESCRIPTION
…(#1501)

Otherwise string collate FN would not be instantiated properly IF dataloader name is None and dataset name is present in dataloader params

(cherry picked from commit 8637ee7e34e0c98a65b6eace2b302f624d10630a)