### PR TITLE
Small improvements to utils

### DIFF
--- a/src/super_gradients/training/utils/distributed_training_utils.py
+++ b/src/super_gradients/training/utils/distributed_training_utils.py
@@ -436,7 +436,8 @@ def maybe_all_reduce_tensor_average(tensor: torch.Tensor) -> torch.Tensor:
     :return:
     """
     if is_distributed():
-        tensor = distributed_all_reduce_tensor_average(tensor=tensor, n=torch.distributed.get_world_size())
+        # .to_dense() is required to ensure we can do maybe_all_reduce_tensor_average(some_vector[3])
+        tensor = distributed_all_reduce_tensor_average(tensor=tensor.to_dense(), n=torch.distributed.get_world_size())
     return tensor
 
 

--- a/src/super_gradients/training/utils/utils.py
+++ b/src/super_gradients/training/utils/utils.py
@@ -38,9 +38,12 @@ def convert_to_tensor(array, dtype=None, device=None):
     :param array: torch.tensor / Numpy array / List
     """
     if not torch.is_tensor(array):
-        array = torch.tensor(array)
-
-    return array.to(device=device, dtype=dtype)
+        if isinstance(array, np.ndarray):
+            return torch.from_numpy(array).to(device=device, dtype=dtype)
+        else:
+            return torch.tensor(array, device=device, dtype=dtype)
+    else:
+        return array.to(device=device, dtype=dtype)
 
 
 class HpmStruct:


### PR DESCRIPTION
Minor PR with two changes:
* Inside `maybe_all_reduce_tensor_average` we enforce reduced tensor is dense. Got crash when tried to observe a specific loss component (`loss[4]` and since indexing does not create a new tensor but rather a view this failed to work with all_reduce).
* `convert_to_tensor` now create tensor from numpy in a bit more efficient fashion straight on target device.