### PR TITLE
Simplify ONNX Graph/ Compatibily GAP9 SDK

### DIFF
--- a/src/super_gradients/training/utils/bbox_utils.py
+++ b/src/super_gradients/training/utils/bbox_utils.py
@@ -16,7 +16,7 @@ def batch_distance2bbox(points: Tensor, distance: Tensor, max_shapes: Optional[T
     """
     lt, rb = torch.split(distance, 2, dim=-1)
     # while tensor add parameters, parameters should be better placed on the second place
-    x1y1 = -lt + points
+    x1y1 = points - lt
     x2y2 = rb + points
     out_bbox = torch.cat([x1y1, x2y2], dim=-1)
     if max_shapes is not None:


### PR DESCRIPTION
I have just simplified the ONNX Graph
Some Hardware Accellerator (like GAP9) don't support Neg operations.

![now](https://github.com/Deci-AI/super-gradients/assets/71791265/c5e8e758-9618-4bd9-a8c3-85a37fc7552e)
![previous](https://github.com/Deci-AI/super-gradients/assets/71791265/88ca4e53-7c02-45e2-9642-87e961c4b5bb)

Referenced here: 
#1555 