### PR TITLE
Remove `np.bool` which is not supported in latest np versions

### DIFF
--- a/src/super_gradients/conversion/conversion_utils.py
+++ b/src/super_gradients/conversion/conversion_utils.py
@@ -12,7 +12,7 @@ _DTYPE_CORRESPONDENCE = [
     (torch.int16, np.int16),
     (torch.int8, np.int8),
     (torch.uint8, np.uint8),
-    (torch.bool, np.bool),
+    (torch.bool, bool),
 ]
 
 


### PR DESCRIPTION
### Issue
Exception when using SG with `numpy==1.25.2`

```
    (torch.bool, np.bool),
../../../../miniconda3/envs/louis-dev/lib/python3.8/site-packages/numpy/__init__.py:305: in __getattr__
    raise AttributeError(__former_attrs__[attr])
E   AttributeError: module 'numpy' has no attribute 'bool'.
E   `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
E   The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
E       https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```


### Proposed solution
`(torch.bool, np.bool),` -> `(torch.bool, bool),`