### PR TITLE
Update Data Gradients version in master_330 branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,4 +36,4 @@ numpy<=1.23
 rapidfuzz
 json-tricks==3.16.1
 onnx-simplifier>=0.3.6,<1.0
-data-gradients>=0.2.1
+data-gradients>=0.2.2


### PR DESCRIPTION
For some reason cherry-pick of the corresponding commit from master failing. So manually bumping version here. Otherwise github showing merge conflict master -> master_330