### PR TITLE
Added packages to pth checkpoint

### DIFF
--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -658,7 +658,7 @@ class Trainer:
         metric = validation_results_dict[self.metric_to_watch]
 
         # BUILD THE state_dict
-        state = {"net": unwrap_model(self.net).state_dict(), "acc": metric, "epoch": epoch}
+        state = {"net": unwrap_model(self.net).state_dict(), "acc": metric, "epoch": epoch, "packages": get_installed_packages()}
 
         if optimizer is not None:
             state["optimizer_state_dict"] = optimizer.state_dict()

--- a/tests/end_to_end_tests/trainer_test.py
+++ b/tests/end_to_end_tests/trainer_test.py
@@ -79,7 +79,7 @@ class TestTrainer(unittest.TestCase):
         ckpt_paths = [os.path.join(trainer.checkpoints_dir_path, suf) for suf in ckpt_filename]
         for ckpt_path in ckpt_paths:
             ckpt = torch.load(ckpt_path)
-            self.assertListEqual(["net", "acc", "epoch", "optimizer_state_dict", "scaler_state_dict"], list(ckpt.keys()))
+            self.assertListEqual(["net", "acc", "epoch", "optimizer_state_dict", "scaler_state_dict", "packages"], list(ckpt.keys()))
         trainer._save_checkpoint()
         weights_only = torch.load(os.path.join(trainer.checkpoints_dir_path, "ckpt_latest_weights_only.pth"))
         self.assertListEqual(["net"], list(weights_only.keys()))

--- a/tests/end_to_end_tests/trainer_test.py
+++ b/tests/end_to_end_tests/trainer_test.py
@@ -79,7 +79,7 @@ class TestTrainer(unittest.TestCase):
         ckpt_paths = [os.path.join(trainer.checkpoints_dir_path, suf) for suf in ckpt_filename]
         for ckpt_path in ckpt_paths:
             ckpt = torch.load(ckpt_path)
-            self.assertListEqual(["net", "acc", "epoch", "optimizer_state_dict", "scaler_state_dict", "packages"], list(ckpt.keys()))
+            self.assertListEqual(sorted(["net", "acc", "epoch", "optimizer_state_dict", "scaler_state_dict", "packages"]), sorted(list(ckpt.keys())))
         trainer._save_checkpoint()
         weights_only = torch.load(os.path.join(trainer.checkpoints_dir_path, "ckpt_latest_weights_only.pth"))
         self.assertListEqual(["net"], list(weights_only.keys()))


### PR DESCRIPTION
### Issue description
@BloodAxe said SG does not support saving metrics, environment, and train config to the checkpoint.

After getting more familiar with a codebase, I realized the task should be split into several parts / PRs. This is a second one ;)

### PR description
This PR proposes a way to add an environment/libs version to a separate field in the checkpoint .pth file.