### PR TITLE
Fixed bug in ModelWeightAveraging class that led to corrupted model when metric to watch was NaN/Inf

### DIFF
--- a/tests/deci_core_unit_test_suite_runner.py
+++ b/tests/deci_core_unit_test_suite_runner.py
@@ -49,6 +49,7 @@ from tests.unit_tests.replace_head_test import ReplaceHeadUnitTest
 from tests.unit_tests.strictload_enum_test import StrictLoadEnumTest
 from tests.unit_tests.test_deprecations import DeprecationsUnitTest
 from tests.unit_tests.test_min_samples_single_node import TestMinSamplesSingleNode
+from tests.unit_tests.test_model_weight_averaging import TestModelWeightAveraging
 from tests.unit_tests.test_train_with_torch_scheduler import TrainWithTorchSchedulerTest
 from tests.unit_tests.test_version_check import TestVersionCheck
 from tests.unit_tests.test_yolo_nas_pose import YoloNASPoseTests
@@ -172,6 +173,7 @@ class CoreUnitTestSuiteRunner:
         self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(DynamicModelTests))
         self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(TestConvertRecipeToCode))
         self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(TestVersionCheck))
+        self.unit_tests_suite.addTest(self.test_loader.loadTestsFromModule(TestModelWeightAveraging))
 
     def _add_modules_to_end_to_end_tests_suite(self):
         """

--- a/tests/unit_tests/test_model_weight_averaging.py
+++ b/tests/unit_tests/test_model_weight_averaging.py
@@ -1,0 +1,70 @@
+import collections
+import tempfile
+import unittest
+
+import numpy as np
+import torch
+from torch import nn
+
+from super_gradients.training.utils.weight_averaging_utils import ModelWeightAveraging
+
+
+class TestModelWeightAveraging(unittest.TestCase):
+    def test_model_weight_averaging_single_model(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            avg = ModelWeightAveraging(
+                ckpt_dir=tmp_dir,
+                greater_is_better=True,
+                metric_to_watch="acc",
+                load_checkpoint=False,
+                number_of_models_to_average=10,
+            )
+
+            model = self._create_dummy_model()
+            model_sd = model.state_dict()
+            avg_model_sd = avg.get_average_model(model, {"acc": 0.99})
+            self.assertStateDictAlmostEqual(avg_model_sd, model_sd)
+
+    def test_model_weight_averaging_with_nan_metric(self):
+        corrupted_metric_values = np.nan, +np.inf, -np.inf, torch.nan, torch.inf, -torch.inf
+
+        for corrupted_metric_value in corrupted_metric_values:
+            with self.subTest(corrupted_metric_value=corrupted_metric_value):
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    avg = ModelWeightAveraging(
+                        ckpt_dir=tmp_dir,
+                        greater_is_better=True,
+                        metric_to_watch="acc",
+                        load_checkpoint=False,
+                        number_of_models_to_average=10,
+                    )
+
+                    model = self._create_dummy_model()
+                    model_sd = model.state_dict()
+                    avg.get_average_model(model, {"acc": 0.99})
+
+                    corrupted_model = self._create_dummy_model()
+                    corrupted_model.fc1.weight.data = torch.randn(10, 10) * torch.nan
+                    avg_model_sd = avg.get_average_model(corrupted_model, {"acc": corrupted_metric_value})
+
+                    self.assertStateDictAlmostEqual(avg_model_sd, model_sd)
+
+    def assertStateDictAlmostEqual(self, sd1, sd2, eps=1e-5):
+        self.assertEqual(set(sd1.keys()), set(sd2.keys()))
+        for key in sd1.keys():
+            v1 = sd1[key]
+            v2 = sd2[key]
+            if torch.is_floating_point(v1) and torch.is_floating_point(v2):
+                difference = torch.nn.functional.l1_loss(v1, v2)
+                self.assertLessEqual(difference, eps, msg=f"{key}: {v1} vs {v2}")
+            else:
+                self.assertEqual(v1, v2)
+
+    def _create_dummy_model(self) -> nn.Module:
+        net = nn.Sequential(collections.OrderedDict([("fc1", nn.Linear(10, 10)), ("bn", nn.BatchNorm1d(10))]))
+        net.fc1.weight.data = torch.randn(10, 10)
+        return net
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A class was not checking whether observed metric is a finite number and included a state dict of the model that had inf/nan metric value into averaging. 

The fix was three-liner:
```
val = float(validation_results_dict[self.metric_to_watch])

if not np.isfinite(val):
  return False, None
```