### PR TITLE
Added support of multiple test loaders in train_from_config

### DIFF
--- a/documentation/source/Data.md
+++ b/documentation/source/Data.md
@@ -305,3 +305,89 @@ Last, in your ``my_train_from_recipe_script.py`` file, import the newly register
   if __name__ == "__main__":
       run()
 ```
+
+### Adding test datasets
+
+In addition to the train and validation datasets, you can also add a test dataset or multiple test datasets to your configuration file.
+At the end of training, metrics from each test dataset will be computed and returned in final results.
+
+#### Single test dataset
+
+To add a single test dataset to recipe, add following properties to your configuration file:
+
+```yaml
+test_dataloaders: <dataloader_name>
+
+dataset_params:
+  test_dataset_params:
+    ...
+
+  test_dataloader_params:
+    ...
+```
+
+
+#### Multiple test datasets
+
+In addition to the train and validation datasets, you can also add a test dataset or multiple test datasets to your configuration file.
+This is how you can achieve this using YAML file:
+
+#### Explicitly specifying all parameters
+
+```yaml
+test_dataloaders:
+  test_dataset_name_1: <dataloader_name>
+  test_dataset_name_2: <dataloader_name>
+
+dataset_params:
+  test_dataset_params:
+   test_dataset_name_1:
+    ...
+   test_dataset_name_2:
+    ...
+
+  test_dataloader_params:
+   test_dataset_name_1:
+    ...
+   test_dataset_name_2:
+    ...
+```
+
+#### Without dataloader names
+
+A `test_dataloaders` property of the configuration file is optional and can be skipped. 
+You may want to use this option when you don't have a dataloader factory method registered. 
+In this case you have to specify a dataset class in corresponding dataloaders params.
+
+```yaml
+dataset_params:
+  test_dataset_params:
+   test_dataset_name_1:
+    ...
+   test_dataset_name_2:
+    ...
+
+  test_dataloader_params:
+   test_dataset_name_1:
+     dataset: <dataset_class_name>
+     ...
+   test_dataset_name_2:
+     dataset: <dataset_class_name>
+     ...
+```
+
+#### Without dataloader params
+
+A `dataset_params.test_dataloader_params` property is optional and can be skipped.
+In this case `dataset_params.val_dataloader_params` will be used for instantiating test dataloaders. 
+Please note that if you don't use `test_dataloaders` and `test_dataloader_params` properties, a `dataset_params.val_dataloader_params` 
+must contain a `dataset` property specifying class name of the dataset to use.
+
+```yaml
+dataset_params:
+  test_dataset_params:
+   test_dataset_name_1:
+    ...
+   test_dataset_name_2:
+    ...
+```

--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -284,6 +284,24 @@ class Trainer:
             dataloader_params=cfg.dataset_params.val_dataloader_params,
         )
 
+        test_loaders = {}
+        if "test_dataset_params" in cfg.dataset_params:
+            test_dataloaders = get_param(cfg, "test_dataloaders")
+            test_dataset_params = cfg.dataset_params.test_dataset_params
+            test_dataloader_params = get_param(cfg.dataset_params, "test_dataloader_params")
+
+            if test_dataloaders is not None:
+                if not isinstance(test_dataloaders, Mapping):
+                    raise ValueError("`test_dataloaders` should be a mapping from test_loader_name to test_loader_params.")
+
+                if test_dataloader_params.keys() != test_dataset_params.keys():
+                    raise ValueError("test_dataloader_params and test_dataset_params should have the same keys.")
+
+            for dataset_name, dataset_params in test_dataset_params.items():
+                loader_name = test_dataloaders[dataset_name] if test_dataloaders is not None else None
+                loader = dataloaders.get(loader_name, dataset_params=test_dataset_params[dataset_name], dataloader_params=test_dataloader_params)
+                test_loaders[dataset_name] = loader
+
         recipe_logged_cfg = {"recipe_config": OmegaConf.to_container(cfg, resolve=True)}
         # TRAIN
         res = trainer.train(

--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -310,7 +310,7 @@ class Trainer:
             model=model,
             train_loader=train_dataloader,
             valid_loader=val_dataloader,
-            test_loaders=None,  # TODO: Add option to set test_loaders in recipe
+            test_loaders=test_loaders,
             training_params=cfg.training_hyperparams,
             additional_configs_to_log=recipe_logged_cfg,
         )

--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -43,6 +43,7 @@ from super_gradients.common.factories.list_factory import ListFactory
 from super_gradients.common.factories.losses_factory import LossesFactory
 from super_gradients.common.factories.metrics_factory import MetricsFactory
 from super_gradients.common.environment.package_utils import get_installed_packages
+from super_gradients.common.environment.cfg_utils import maybe_instantiate_test_loaders
 
 from super_gradients.training import utils as core_utils, models, dataloaders
 from super_gradients.training.datasets.samplers import RepeatAugSampler
@@ -284,25 +285,7 @@ class Trainer:
             dataloader_params=cfg.dataset_params.val_dataloader_params,
         )
 
-        test_loaders = {}
-        if "test_dataset_params" in cfg.dataset_params:
-            test_dataloaders = get_param(cfg, "test_dataloaders")
-            test_dataset_params = cfg.dataset_params.test_dataset_params
-            test_dataloader_params = get_param(cfg.dataset_params, "test_dataloader_params")
-
-            if test_dataloaders is not None:
-                if not isinstance(test_dataloaders, Mapping):
-                    raise ValueError("`test_dataloaders` should be a mapping from test_loader_name to test_loader_params.")
-
-                if test_dataloader_params is not None and test_dataloader_params.keys() != test_dataset_params.keys():
-                    raise ValueError("test_dataloader_params and test_dataset_params should have the same keys.")
-
-            for dataset_name, dataset_params in test_dataset_params.items():
-                loader_name = test_dataloaders[dataset_name] if test_dataloaders is not None else None
-                dataset_params = test_dataset_params[dataset_name]
-                dataloader_params = test_dataloader_params[dataset_name] if test_dataloader_params is not None else cfg.dataset_params.val_dataloader_params
-                loader = dataloaders.get(loader_name, dataset_params=dataset_params, dataloader_params=dataloader_params)
-                test_loaders[dataset_name] = loader
+        test_loaders = maybe_instantiate_test_loaders(cfg)
 
         recipe_logged_cfg = {"recipe_config": OmegaConf.to_container(cfg, resolve=True)}
         # TRAIN

--- a/tests/unit_tests/configs/cifar10_multiple_test.yaml
+++ b/tests/unit_tests/configs/cifar10_multiple_test.yaml
@@ -1,0 +1,50 @@
+defaults:
+  - cifar10_resnet
+
+test_dataloaders:
+  cifar10: cifar10_val
+  cifar100: cifar100_val
+
+dataset_params:
+  test_dataset_params:
+    cifar10:
+      root: ./data/cifar10
+      train: False
+      transforms:
+        - Resize:
+            size: 32
+        - ToTensor
+        - Normalize:
+            mean:
+              - 0.4914
+              - 0.4822
+              - 0.4465
+            std:
+              - 0.2023
+              - 0.1994
+              - 0.2010
+      target_transform: null
+      download: True
+
+    cifar100:
+      root: ./data/cifar100
+      train: False
+      transforms:
+        - Resize:
+            size: 32
+        - ToTensor
+        - Normalize:
+            mean:
+              - 0.4914
+              - 0.4822
+              - 0.4465
+            std:
+              - 0.2023
+              - 0.1994
+              - 0.2010
+      target_transform: null
+      download: True
+
+hydra:
+  searchpath:
+    - pkg://super_gradients.recipes

--- a/tests/unit_tests/configs/cifar10_multiple_test.yaml
+++ b/tests/unit_tests/configs/cifar10_multiple_test.yaml
@@ -3,9 +3,15 @@ defaults:
 
 test_dataloaders:
   cifar10: cifar10_val
-  cifar100: cifar100_val
+  cifar10_v2: cifar10_val
 
 dataset_params:
+  train_dataloader_params:
+    num_workers: 0
+
+  val_dataloader_params:
+    num_workers: 0
+
   test_dataset_params:
     cifar10:
       root: ./data/cifar10
@@ -26,8 +32,8 @@ dataset_params:
       target_transform: null
       download: True
 
-    cifar100:
-      root: ./data/cifar100
+    cifar10_v2:
+      root: ./data/cifar10
       train: False
       transforms:
         - Resize:
@@ -35,13 +41,13 @@ dataset_params:
         - ToTensor
         - Normalize:
             mean:
-              - 0.4914
-              - 0.4822
-              - 0.4465
+              - 0.5
+              - 0.5
+              - 0.5
             std:
-              - 0.2023
-              - 0.1994
-              - 0.2010
+              - 0.2
+              - 0.2
+              - 0.2
       target_transform: null
       download: True
 

--- a/tests/unit_tests/train_with_intialized_param_args_test.py
+++ b/tests/unit_tests/train_with_intialized_param_args_test.py
@@ -1,12 +1,17 @@
+import os
 import unittest
 
+import hydra
 import numpy as np
 import torch
+from hydra.core.global_hydra import GlobalHydra
 from torch.optim import SGD
 from torch.optim.lr_scheduler import ReduceLROnPlateau, MultiStepLR
 from torchmetrics import F1Score
 
 from super_gradients import Trainer
+from super_gradients.common.environment.omegaconf_utils import register_hydra_resolvers
+from super_gradients.common.environment.path_utils import normalize_path
 from super_gradients.common.object_names import Models
 from super_gradients.training import models
 from super_gradients.training.dataloaders.dataloaders import classification_test_dataloader
@@ -188,6 +193,17 @@ class TrainWithInitializedObjectsTest(unittest.TestCase):
             "greater_metric_to_watch_is_better": True,
         }
         trainer.train(model=model, training_params=train_params, train_loader=train_loader, valid_loader=val_loader)
+
+    def test_train_with_multiple_test_loaders(self):
+        register_hydra_resolvers()
+        GlobalHydra.instance().clear()
+        configs_dir = os.path.join(os.path.dirname(__file__), "configs")
+        with hydra.initialize_config_dir(config_dir=normalize_path(configs_dir), version_base="1.2"):
+            cfg = hydra.compose(config_name="cifar10_multiple_test")
+
+        cfg.training_hyperparams.max_epochs = 5
+        trained_model, metrics = Trainer.train_from_config(cfg)
+        print(metrics)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/train_with_intialized_param_args_test.py
+++ b/tests/unit_tests/train_with_intialized_param_args_test.py
@@ -201,9 +201,8 @@ class TrainWithInitializedObjectsTest(unittest.TestCase):
         with hydra.initialize_config_dir(config_dir=normalize_path(configs_dir), version_base="1.2"):
             cfg = hydra.compose(config_name="cifar10_multiple_test")
 
-        cfg.training_hyperparams.max_epochs = 5
-        trained_model, metrics = Trainer.train_from_config(cfg)
-        print(metrics)
+        cfg.training_hyperparams.max_epochs = 1
+        Trainer.train_from_config(cfg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
How it supposed to look in YAML file

```
defaults:
  - cifar10_resnet

test_dataloaders:
  cifar10: cifar10_val
  cifar100: cifar100_val

dataset_params:
  test_dataset_params:
    cifar10:
      root: ./data/cifar10
      train: False
      transforms:
        - Resize:
            size: 32
        - ToTensor
        - Normalize:
            mean:
              - 0.4914
              - 0.4822
              - 0.4465
            std:
              - 0.2023
              - 0.1994
              - 0.2010
      target_transform: null
      download: True

    cifar100:
      root: ./data/cifar100
      train: False
      transforms:
        - Resize:
            size: 32
        - ToTensor
        - Normalize:
            mean:
              - 0.4914
              - 0.4822
              - 0.4465
            std:
              - 0.2023
              - 0.1994
              - 0.2010
      target_transform: null
      download: True

hydra:
  searchpath:
    - pkg://super_gradients.recipes

```