### PR TITLE
Fix Invalid syntax at convert_recipe_to_code.py

### DIFF
--- a/src/super_gradients/convert_recipe_to_code.py
+++ b/src/super_gradients/convert_recipe_to_code.py
@@ -179,13 +179,13 @@ def main():
     )
 
     train_dataloader = dataloaders.get(
-        name="{train_dataloader}",
+        name={wrap_in_quotes_if_string(train_dataloader)},
         dataset_params={train_dataset_params},
         dataloader_params={train_dataloader_params},
     )
 
     val_dataloader = dataloaders.get(
-        name="{val_dataloader}",
+        name={wrap_in_quotes_if_string(val_dataloader)},
         dataset_params={val_dataset_params},
         dataloader_params={val_dataloader_params},
     )

--- a/src/super_gradients/convert_recipe_to_code.py
+++ b/src/super_gradients/convert_recipe_to_code.py
@@ -179,13 +179,13 @@ def main():
     )
 
     train_dataloader = dataloaders.get(
-        name={train_dataloader},
+        name="{train_dataloader}",
         dataset_params={train_dataset_params},
         dataloader_params={train_dataloader_params},
     )
 
     val_dataloader = dataloaders.get(
-        name={val_dataloader},
+        name="{val_dataloader}",
         dataset_params={val_dataset_params},
         dataloader_params={val_dataloader_params},
     )


### PR DESCRIPTION
I added **double quotes** around the name parameter in dataloaders.get() in the code below.

```
    train_dataloader = dataloaders.get(
        name="{train_dataloader}",
        dataset_params={train_dataset_params},
        dataloader_params={train_dataloader_params},
    )
    val_dataloader = dataloaders.get(
        name="{val_dataloader}",
        dataset_params={val_dataset_params},
        dataloader_params={val_dataloader_params},
    )
```
