### PR TITLE
Albumentations support for detectionsample

### DIFF
--- a/src/super_gradients/training/datasets/detection_datasets/detection_dataset.py
+++ b/src/super_gradients/training/datasets/detection_datasets/detection_dataset.py
@@ -478,6 +478,8 @@ class DetectionDataset(Dataset, HasPreprocessingParams):
                 LegacyDetectionTransformMixin.convert_input_dict_to_detection_sample(s) for s in self._get_additional_inputs_for_transform(transform=transform)
             ]
             detection_sample = transform.apply_to_sample(sample=detection_sample)
+            detection_sample = detection_sample.sanitize_sample()
+
             detection_sample.additional_samples = None
             if isinstance(transform, DetectionTargetsFormatTransform):
                 target_format_transform = transform
@@ -540,7 +542,8 @@ class DetectionDataset(Dataset, HasPreprocessingParams):
 
                 if plot_transformed_data:
                     image, targets, *_ = self[img_i + plot_i * 16]
-                    image = image.transpose(1, 2, 0).astype(np.int32)
+                    if image.shape[0] == 3:
+                        image = image.transpose(1, 2, 0).astype(np.int32)
                 else:
                     sample = self.get_sample(index=index, ignore_empty_annotations=self.ignore_empty_annotations)
                     image, targets = sample["image"], sample["target"]

--- a/src/super_gradients/training/samples/detection_sample.py
+++ b/src/super_gradients/training/samples/detection_sample.py
@@ -63,6 +63,7 @@ class DetectionSample:
         self.labels = labels
         self.is_crowd = is_crowd
         self.additional_samples = additional_samples
+        self.sanitize_sample()
 
     def sanitize_sample(self) -> "DetectionSample":
         """
@@ -73,6 +74,7 @@ class DetectionSample:
         """
         image_height, image_width = self.image.shape[:2]
         self.bboxes_xyxy = change_bbox_bounds_for_image_size(self.bboxes_xyxy, img_shape=(image_height, image_width))
+        self.filter_by_bbox_area(0)
         return self
 
     def filter_by_mask(self, mask: np.ndarray) -> "DetectionSample":
@@ -102,5 +104,5 @@ class DetectionSample:
         """
         bboxes_xywh = xyxy_to_xywh(self.bboxes_xyxy, image_shape=None)
         area = bboxes_xywh[..., 2:4].prod(axis=-1)
-        keep_mask = area >= min_bbox_area
+        keep_mask = area > min_bbox_area
         return self.filter_by_mask(keep_mask)

--- a/src/super_gradients/training/transforms/pipeline_adaptors.py
+++ b/src/super_gradients/training/transforms/pipeline_adaptors.py
@@ -1,6 +1,14 @@
+from enum import Enum
 from typing import Callable
 from abc import abstractmethod, ABC
 import numpy as np
+
+from super_gradients.training.samples import DetectionSample
+
+
+class SampleType(Enum):
+    DETECTION = "DETECTION"
+    IMAGE_ONLY = "IMAGE_ONLY"
 
 
 class TransformsPipelineAdaptorBase(ABC):
@@ -23,15 +31,42 @@ class TransformsPipelineAdaptorBase(ABC):
 class AlbumentationsAdaptor(TransformsPipelineAdaptorBase):
     def __init__(self, composed_transforms: Callable):
         super(AlbumentationsAdaptor, self).__init__(composed_transforms)
+        self.sample_type = None
 
     def __call__(self, sample, *args, **kwargs):
+        if isinstance(sample, DetectionSample):
+            self.sample_type = SampleType.DETECTION
+        else:
+            self.sample_type = SampleType.IMAGE_ONLY
+
         sample = self.prep_for_transforms(sample)
-        sample = self.composed_transforms(**sample)["image"]
+        sample = self.composed_transforms(**sample)
         sample = self.post_transforms_processing(sample)
         return sample
 
+    def apply_to_sample(self, sample):
+        return self(sample=sample)
+
     def prep_for_transforms(self, sample):
-        return {"image": np.array(sample)}
+        if self.sample_type == SampleType.DETECTION:
+            sample = {"image": sample.image, "bboxes": sample.bboxes_xyxy, "labels": sample.labels, "is_crowd": sample.is_crowd}
+        else:
+            sample = {"image": np.array(sample)}
+        return sample
 
     def post_transforms_processing(self, sample):
-        return sample
+        if self.sample_type == SampleType.DETECTION:
+            if len(sample["bboxes"]) == 0:
+                sample["bboxes"] = np.zeros((0, 4))
+            if len(sample["labels"]) == 0:
+                sample["labels"] = np.zeros((0))
+            if len(sample["is_crowd"]) == 0:
+                sample["is_crowd"] = np.zeros((0))
+            return DetectionSample(
+                image=sample["image"],
+                bboxes_xyxy=np.array(sample["bboxes"]),
+                labels=np.array(sample["labels"]),
+                is_crowd=np.array(sample["is_crowd"]),
+                additional_samples=None,
+            )
+        return sample["image"]

--- a/src/super_gradients/training/utils/detection_utils.py
+++ b/src/super_gradients/training/utils/detection_utils.py
@@ -185,8 +185,8 @@ def change_bbox_bounds_for_image_size(boxes: np.ndarray, img_shape: Tuple[int, i
     :param img_shape:  Tuple[int,int] of image shape (height, width).
     :return:           (np.ndarray)clipped bboxes in XYXY format of [..., 4] shape
     """
-    boxes[..., [0, 2]] = boxes[..., [0, 2]].clamp(min=0, max=img_shape[1] - 1)
-    boxes[..., [1, 3]] = boxes[..., [1, 3]].clamp(min=0, max=img_shape[0] - 1)
+    boxes[..., [0, 2]] = boxes[..., [0, 2]].clip(min=0, max=img_shape[1])
+    boxes[..., [1, 3]] = boxes[..., [1, 3]].clip(min=0, max=img_shape[0])
     return boxes
 
 


### PR DESCRIPTION
- Introduces albumentations support, as done in the added integration test.
- Fixed DetectionDataset.plot() to support channels last.
- Fix for np.array.clip instead of torch.clamp in sanitise_sample.
- Call sanitize_sample after each transform and on init to ensure nothing has been corrupted.