### PR TITLE
Use onnxsim and not onnx-simplifier (Same package but different name)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,5 @@ stringcase>=1.2.0
 numpy<=1.23
 rapidfuzz
 json-tricks==3.16.1
-onnx-simplifier>=0.4.3,<1.0
+onnxsim>=0.4.3,<1.0
 data-gradients~=0.3.1


### PR DESCRIPTION
Fixes https://github.com/Deci-AI/super-gradients/issues/1664

Why it happens: `onnxsim` and `onnx-simplifier` are the same packages that author upload to pypi automatically, but the default one "onnxsim". When on installs onnxsim from source the package metadata does not match, because we have in requirements.txt the `onnx-simplifier` and the default package name is `onnxsim` in the repository.