### PR TITLE
Update post_prediction_callback.py: remove unused param

### DIFF
--- a/src/super_gradients/training/models/detection_models/pp_yolo_e/post_prediction_callback.py
+++ b/src/super_gradients/training/models/detection_models/pp_yolo_e/post_prediction_callback.py
@@ -27,11 +27,10 @@ class PPYoloEPostPredictionCallback(DetectionPostPredictionCallback):
         self.max_predictions = max_predictions
         self.multi_label_per_box = multi_label_per_box
 
-    def forward(self, outputs, device: str):
+    def forward(self, outputs):
         """
 
         :param x: Tuple of (bboxes, scores) of shape [B, Anchors, 4], [B, Anchors, C]
-        :param device:
         :return:
         """
         nms_result = []


### PR DESCRIPTION
### Problem Description
When I followed the [docs](https://docs.deci.ai/super-gradients/latest/documentation/source/ObjectDetection.html) > Object Detection > Visualization of predictions after training using PP_YOLOE_S and executed the following code

```python
import torch
import numpy as np

from super_gradients.training import models
from super_gradients.training.utils.detection_utils import DetectionVisualization
from super_gradients.training.datasets.datasets_conf import COCO_DETECTION_CLASSES_LIST


def my_undo_image_preprocessing(im_tensor: torch.Tensor) -> np.ndarray:
    im_np = im_tensor.cpu().numpy()
    im_np = im_np[:, ::-1, :, :].transpose(0, 2, 3, 1)
    im_np *= 255.0
    return np.ascontiguousarray(im_np, dtype=np.uint8)


model = models.get("yolox_s", pretrained_weights="coco", num_classes=80)
imgs, targets = next(iter(train_dataloader))
preds = model.get_post_prediction_callback(conf=0.1, iou=0.6)(model(imgs))
DetectionVisualization.visualize_batch(imgs, preds, targets, batch_name='train', class_names=COCO_DETECTION_CLASSES_LIST,
                                       checkpoint_dir='/path/for/saved_images/', gt_alpha=0.5,
                                       undo_preprocessing_func=my_undo_image_preprocessing)
```

I got an error: `forward() missing 1 required positional argument: 'device'`

## Proposed change
After reviewing the source code, the param `device` seems unused, so it could be safely removed to avoid the error.