### PR TITLE
Make `(QA)RepVGG` NAS-able using similar API as `ConvBnAct`

### DIFF
--- a/src/super_gradients/modules/qarepvgg_block.py
+++ b/src/super_gradients/modules/qarepvgg_block.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Type, Union, Mapping, Any, Optional
 
 import torch
@@ -60,8 +61,7 @@ class QARepVGGBlock(nn.Module):
         use_alpha: bool = False,
         use_1x1_bias: bool = True,
         use_post_bn: bool = True,
-        kernel_size: int = 3,
-        padding: int = 1,
+        **kwargs,
     ):
         """
         :param in_channels: Number of input channels
@@ -78,18 +78,12 @@ class QARepVGGBlock(nn.Module):
         :param use_alpha: If True, enables additional learnable weighting parameter for 1x1 branch (PP-Yolo-E Plus)
         :param use_1x1_bias: If True, enables bias in the 1x1 convolution, authors don't mention it specifically
         :param use_post_bn: If True, adds BatchNorm after the sum of three branches (S4), if False, BatchNorm is not added (S3)
-        :param kernel_size: The kernel size. Should be fixed to `kernel_size=3`. Used to allow API which is similar to `ConvBnAct`.
-        :param padding: The padding size. Should be fixed to `padding=dilation`. Used to allow API which is similar to `ConvBnAct`.
         """
-        if kernel_size != 3:
-            raise ValueError(
-                f"{QARepVGGBlock.__name__} only supports kernel_size=3 (got: {kernel_size}). The `kernel_size` argument is to allow NAS with different blocks"
-            )
+        if "kernel_size" in kwargs and kwargs.get("kernel_size") != 3:
+            logging.warning(f"{RepVGGBlock.__name__} only supports kernel_size=3. The `kernel_size` argument passed in `kwargs` will be ignored")
 
-        if padding != dilation:
-            raise ValueError(
-                f"{QARepVGGBlock.__name__} only supports padding=dilation (got: {padding}). The `padding` argument is to allow NAS with different blocks"
-            )
+        if "padding" in kwargs and kwargs.get("padding") != dilation:
+            logging.warning(f"{RepVGGBlock.__name__} only supports padding=dilation. The `padding` argument passed in `kwargs` will be ignored")
 
         super().__init__()
 

--- a/src/super_gradients/modules/qarepvgg_block.py
+++ b/src/super_gradients/modules/qarepvgg_block.py
@@ -60,6 +60,8 @@ class QARepVGGBlock(nn.Module):
         use_alpha: bool = False,
         use_1x1_bias: bool = True,
         use_post_bn: bool = True,
+        kernel_size: int = 3,
+        padding: int = 1,
     ):
         """
         :param in_channels: Number of input channels
@@ -76,7 +78,19 @@ class QARepVGGBlock(nn.Module):
         :param use_alpha: If True, enables additional learnable weighting parameter for 1x1 branch (PP-Yolo-E Plus)
         :param use_1x1_bias: If True, enables bias in the 1x1 convolution, authors don't mention it specifically
         :param use_post_bn: If True, adds BatchNorm after the sum of three branches (S4), if False, BatchNorm is not added (S3)
+        :param kernel_size: The kernel size. Should be fixed to `kernel_size=3`. Used to allow API which is similar to `ConvBnAct`.
+        :param padding: The padding size. Should be fixed to `padding=dilation`. Used to allow API which is similar to `ConvBnAct`.
         """
+        if kernel_size != 3:
+            raise ValueError(
+                f"{QARepVGGBlock.__name__} only supports kernel_size=3 (got: {kernel_size}). The `kernel_size` argument is to allow NAS with different blocks"
+            )
+
+        if padding != dilation:
+            raise ValueError(
+                f"{QARepVGGBlock.__name__} only supports padding=dilation (got: {padding}). The `padding` argument is to allow NAS with different blocks"
+            )
+
         super().__init__()
 
         if activation_kwargs is None:

--- a/src/super_gradients/modules/repvgg_block.py
+++ b/src/super_gradients/modules/repvgg_block.py
@@ -29,6 +29,8 @@ class RepVGGBlock(nn.Module):
         build_residual_branches: bool = True,
         use_residual_connection: bool = True,
         use_alpha: bool = False,
+        kernel_size=3,
+        padding=1,
     ):
         """
 
@@ -44,7 +46,20 @@ class RepVGGBlock(nn.Module):
         :param build_residual_branches: Whether to initialize block with already fused paramters (for deployment)
         :param use_residual_connection: Whether to add input x to the output (Enabled in RepVGG, disabled in PP-Yolo)
         :param use_alpha: If True, enables additional learnable weighting parameter for 1x1 branch (PP-Yolo-E Plus)
+        :param kernel_size: The kernel size. Should be fixed to `kernel_size=3`. Used to allow API which is similar to `ConvBnAct`.
+        :param kernel_size: The padding size. Should be fixed to `padding=dilation`. Used to allow API which is similar to `ConvBnAct`.
         """
+
+        if kernel_size != 3:
+            raise ValueError(
+                f"{RepVGGBlock.__name__} only supports kernel_size=3 (got: {kernel_size}). The `kernel_size` argument is to allow NAS with different blocks"
+            )
+
+        if padding != dilation:
+            raise ValueError(
+                f"{RepVGGBlock.__name__} only supports padding=dilation (got: {padding}). The `padding` argument is to allow NAS with different blocks"
+            )
+
         super().__init__()
 
         if activation_kwargs is None:

--- a/src/super_gradients/modules/repvgg_block.py
+++ b/src/super_gradients/modules/repvgg_block.py
@@ -46,8 +46,6 @@ class RepVGGBlock(nn.Module):
         :param build_residual_branches: Whether to initialize block with already fused paramters (for deployment)
         :param use_residual_connection: Whether to add input x to the output (Enabled in RepVGG, disabled in PP-Yolo)
         :param use_alpha: If True, enables additional learnable weighting parameter for 1x1 branch (PP-Yolo-E Plus)
-        :param kernel_size: The kernel size. Should be fixed to `kernel_size=3`. Used to allow API which is similar to `ConvBnAct`.
-        :param padding: The padding size. Should be fixed to `padding=dilation`. Used to allow API which is similar to `ConvBnAct`.
         """
 
         if "kernel_size" in kwargs and kwargs.get("kernel_size") != 3:

--- a/src/super_gradients/modules/repvgg_block.py
+++ b/src/super_gradients/modules/repvgg_block.py
@@ -47,7 +47,7 @@ class RepVGGBlock(nn.Module):
         :param use_residual_connection: Whether to add input x to the output (Enabled in RepVGG, disabled in PP-Yolo)
         :param use_alpha: If True, enables additional learnable weighting parameter for 1x1 branch (PP-Yolo-E Plus)
         :param kernel_size: The kernel size. Should be fixed to `kernel_size=3`. Used to allow API which is similar to `ConvBnAct`.
-        :param kernel_size: The padding size. Should be fixed to `padding=dilation`. Used to allow API which is similar to `ConvBnAct`.
+        :param padding: The padding size. Should be fixed to `padding=dilation`. Used to allow API which is similar to `ConvBnAct`.
         """
 
         if kernel_size != 3:

--- a/src/super_gradients/modules/repvgg_block.py
+++ b/src/super_gradients/modules/repvgg_block.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Type, Union, Mapping, Any, Optional
 
 import numpy as np
@@ -29,8 +30,7 @@ class RepVGGBlock(nn.Module):
         build_residual_branches: bool = True,
         use_residual_connection: bool = True,
         use_alpha: bool = False,
-        kernel_size: int = 3,
-        padding: int = 1,
+        **kwargs,
     ):
         """
 
@@ -50,15 +50,11 @@ class RepVGGBlock(nn.Module):
         :param padding: The padding size. Should be fixed to `padding=dilation`. Used to allow API which is similar to `ConvBnAct`.
         """
 
-        if kernel_size != 3:
-            raise ValueError(
-                f"{RepVGGBlock.__name__} only supports kernel_size=3 (got: {kernel_size}). The `kernel_size` argument is to allow NAS with different blocks"
-            )
+        if "kernel_size" in kwargs and kwargs.get("kernel_size") != 3:
+            logging.warning(f"{RepVGGBlock.__name__} only supports kernel_size=3. The `kernel_size` argument passed in `kwargs` will be ignored")
 
-        if padding != dilation:
-            raise ValueError(
-                f"{RepVGGBlock.__name__} only supports padding=dilation (got: {padding}). The `padding` argument is to allow NAS with different blocks"
-            )
+        if "padding" in kwargs and kwargs.get("padding") != dilation:
+            logging.warning(f"{RepVGGBlock.__name__} only supports padding=dilation. The `padding` argument passed in `kwargs` will be ignored")
 
         super().__init__()
 

--- a/src/super_gradients/modules/repvgg_block.py
+++ b/src/super_gradients/modules/repvgg_block.py
@@ -29,8 +29,8 @@ class RepVGGBlock(nn.Module):
         build_residual_branches: bool = True,
         use_residual_connection: bool = True,
         use_alpha: bool = False,
-        kernel_size=3,
-        padding=1,
+        kernel_size: int = 3,
+        padding: int = 1,
     ):
         """
 


### PR DESCRIPTION
Background: when applying neural architecture search, one might want to experiment with different blocks. To be able to easily experiment different blocks, all "searchable" blocks should contain a shared core API.

For Conv blocks, `kernel_size` and `padding` are part of the core API. This however, is not relevant for `RepVGG` blocks (and variants), because these blocks only support `3x3` and `dilation` kernel size and padding, respectively.

This PR adds `kernel_size` and `padding` to be part of the RepVGG variants' API, so these blocks become easily searchable, and on the other hand also checks that the values passed are those which are indeed supported.
