### PR TITLE
Feature/sg 1196 fix breaking change test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,8 @@ jobs:
             python3 -m pip install -r requirements.dev.txt
             python3 -m pip install gitpython==3.1.0
 
-            # GET THE BRANCH THAT THE CURRENT PR IS BEING MERGED INTO
+            # GET THE BRANCH THAT THE CURRENT PR IS BEING MERGED INTO.
+            # THIS IS ONLY RELEVANT FOR CI RUNS, WHICH IS WHY IT'S NOT PART OF THE PYTHON CODE.
             if [ -n "${CIRCLE_PULL_REQUEST}" ]; then
               PR_NUMBER=$(basename ${CIRCLE_PULL_REQUEST})
               echo "Pull Request Number: ${PR_NUMBER}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,8 +245,27 @@ jobs:
             python3 -m pip install -e .
             python3 -m pip install -r requirements.dev.txt
             python3 -m pip install gitpython==3.1.0
+
+            # GET THE BRANCH THAT THE CURRENT PR IS BEING MERGED INTO
+            if [ -n "${CIRCLE_PULL_REQUEST}" ]; then
+              PR_NUMBER=$(basename ${CIRCLE_PULL_REQUEST})
+              echo "Pull Request Number: ${PR_NUMBER}"
+      
+              # Use GitHub API to get the target branch name of the PR using GITHUB_CLI_TOKEN
+              BRANCH_MERGED_INTO=$(curl -s -H "Authorization: token ${GITHUB_CLI_TOKEN}" \
+                "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" \
+                | jq -r '.base.ref')
+              echo "Branch merged into: `${BRANCH_MERGED_INTO}`"
+            
+              # This is required since it's possible this branch would not be available locally
+              git fetch origin ${BRANCH_MERGED_INTO}:${BRANCH_MERGED_INTO}
+            else
+              echo "This job does not appear to be running as part of a pull request."
+            fi
+
+            # TESTS
             coverage run --source=super_gradients -m unittest tests/breaking_change_tests/unit_test.py
-            coverage run --source=super_gradients -m unittest tests/breaking_change_tests/test_detect_breaking_change.py
+            BRANCH_MERGED_INTO=${BRANCH_MERGED_INTO} coverage run --source=super_gradients -m unittest tests/breaking_change_tests/test_detect_breaking_change.py
             make check_notebooks_version_match
       - run:
           name: Remove new environment when failed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,7 @@ jobs:
               BRANCH_MERGED_INTO=$(curl -s -H "Authorization: token ${GITHUB_CLI_TOKEN}" \
                 "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" \
                 | jq -r '.base.ref')
-              echo "Branch merged into: `${BRANCH_MERGED_INTO}`"
+              echo "Branch merged into: ${BRANCH_MERGED_INTO}"
             
               # This is required since it's possible this branch would not be available locally
               git fetch origin ${BRANCH_MERGED_INTO}:${BRANCH_MERGED_INTO}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,6 +262,7 @@ jobs:
               git fetch origin ${BRANCH_MERGED_INTO}:${BRANCH_MERGED_INTO}
             else
               echo "This job does not appear to be running as part of a pull request."
+              BRANCH_MERGED_INTO="master"
             fi
 
             # TESTS

--- a/tests/breaking_change_tests/breaking_changes_detection.py
+++ b/tests/breaking_change_tests/breaking_changes_detection.py
@@ -214,11 +214,14 @@ def extract_code_breaking_changes(module_path: str, source_code: str, current_co
     return breaking_changes
 
 
-def analyze_breaking_changes(verbose: bool = 1) -> List[Dict[str, Union[str, List]]]:
+def analyze_breaking_changes(verbose: bool = 1, source_branch: str = "master") -> List[Dict[str, Union[str, List]]]:
     """Analyze changes between the current branch (HEAD) and the master branch.
-    :param verbose: If True, print the summary of breaking changes in a nicely formatted way
+    :param verbose:         If True, print the summary of breaking changes in a nicely formatted way
+    :param source_branch:   The branch source branch, to which we will compare the HEAD.
     :return:        List of changes, where each change is a dictionary listing each type of change for each module.
     """
+    print("\n" + "=" * 50)
+    print(f"Analyzing breaking changes, comparing `HEAD` to `{source_branch}`...")
     # GitHelper requires `git` library which should NOT be required for the other functions
     from .git_utils import GitHelper
 
@@ -227,7 +230,7 @@ def analyze_breaking_changes(verbose: bool = 1) -> List[Dict[str, Union[str, Lis
 
     changed_sg_modules = [
         module_path
-        for module_path in git_explorer.diff_files(source_branch="master", current_branch="HEAD")
+        for module_path in git_explorer.diff_files(source_branch=source_branch, current_branch="HEAD")
         if module_path.startswith("src/super_gradients/") and not module_path.startswith("src/super_gradients/examples/")
     ]
 
@@ -235,7 +238,7 @@ def analyze_breaking_changes(verbose: bool = 1) -> List[Dict[str, Union[str, Lis
     breaking_changes_list = []
     for module_path in changed_sg_modules:
 
-        master_code = git_explorer.load_branch_file(branch="master", file_path=module_path)
+        master_code = git_explorer.load_branch_file(branch=source_branch, file_path=module_path)
         head_code = git_explorer.load_branch_file(branch="HEAD", file_path=module_path)
         breaking_changes = extract_code_breaking_changes(module_path=module_path, source_code=master_code, current_code=head_code)
 

--- a/tests/breaking_change_tests/test_detect_breaking_change.py
+++ b/tests/breaking_change_tests/test_detect_breaking_change.py
@@ -1,10 +1,13 @@
+import os
 import unittest
 from .breaking_changes_detection import analyze_breaking_changes
 
 
 class BreakingChangeTest(unittest.TestCase):
     def test_detect_breaking_change(self):
-        breaking_changes_list = analyze_breaking_changes(verbose=True)
+
+        source_branch = os.getenv("BRANCH_MERGED_INTO", "master")
+        breaking_changes_list = analyze_breaking_changes(verbose=True, source_branch=source_branch)
         self.assertEqual(len(breaking_changes_list), 0, f"{len(breaking_changes_list)} breaking changes detected")
 
 


### PR DESCRIPTION
Instead of always checking the breaking change relatively to `master`, this PR first fetches the name of the branch that the current PR is being merging into (this could be something like `master/2.0.0` for instance).
In order to test this, I created a dummy PR (https://github.com/Deci-AI/super-gradients/pull/1731) that introduces a breaking change and is being merged to this branch. You can see in the logs that the "source" branch is not master, but is `feature/SG-1196-fix_breaking_change_test` as expected.