### PR TITLE
PPYoloELoss not does not require reg_max parameter

### DIFF
--- a/src/super_gradients/recipes/training_hyperparams/coco2017_ppyoloe_train_params.yaml
+++ b/src/super_gradients/recipes/training_hyperparams/coco2017_ppyoloe_train_params.yaml
@@ -21,7 +21,6 @@ save_ckpt_epoch_list: [200, 250, 300, 350, 400, 450]
 loss: PPYoloELoss
 criterion_params:
   num_classes: ${arch_params.num_classes}
-  reg_max: ${arch_params.head.reg_max}
 
 optimizer: AdamW
 optimizer_params:

--- a/src/super_gradients/recipes/training_hyperparams/coco2017_yolo_nas_train_params.yaml
+++ b/src/super_gradients/recipes/training_hyperparams/coco2017_yolo_nas_train_params.yaml
@@ -23,7 +23,6 @@ loss: PPYoloELoss
 criterion_params:
   use_static_assigner: False
   num_classes: ${arch_params.num_classes}
-  reg_max: 16
 
 optimizer: AdamW
 optimizer_params:

--- a/src/super_gradients/training/losses/ppyolo_loss.py
+++ b/src/super_gradients/training/losses/ppyolo_loss.py
@@ -657,7 +657,7 @@ class PPYoloELoss(nn.Module):
         :param classification_loss_weight: Classification loss weight
         :param iou_loss_weight:            IoU loss weight
         :param dfl_loss_weight:            DFL loss weight
-        :param reg_max:                    Number of regression bins (Must match the number of bins in the PPYoloE head)
+        :param reg_max:                    (Deprecated) Number of regression bins. Default is None (will be inferred from model's outputs)
         :param use_batched_assignment:     Whether to use batched targets assignment or sequential (per-image).
                                            Default is True (batched).
                                            Batched assignment can be faster when number of the target per image is more or

--- a/src/super_gradients/training/losses/ppyolo_loss.py
+++ b/src/super_gradients/training/losses/ppyolo_loss.py
@@ -667,8 +667,9 @@ class PPYoloELoss(nn.Module):
         """
         if reg_max is not None:
             warnings.warn(
-                "reg_max is not needed for PPYoloE loss anymore. "
-                "You can safely omit this argument as it is not used anymore and we infer it automatically from model's outputs"
+                "A reg_max argument is not needed for PPYoloE loss anymore. It is deprecated since SG 3.6.0 and will be removed in the SG 3.8.0."
+                "You can safely omit this argument as it is not used anymore and we infer it automatically from model's outputs",
+                DeprecationWarning,
             )
         super().__init__()
         self.use_varifocal_loss = use_varifocal_loss


### PR DESCRIPTION
This PR drops the necessity to specify `reg_max` argument in the Loss which should match with the reg_max in the model.
We have all the infromation to infer it's value solely from model's outputs.