### PR TITLE
Improve DetectionMetrics implementation to properly handle score_thresholds

### DIFF
--- a/src/super_gradients/training/metrics/detection_metrics.py
+++ b/src/super_gradients/training/metrics/detection_metrics.py
@@ -83,7 +83,7 @@ class DetectionMetrics(Metric):
         top_k_predictions: int = 100,
         dist_sync_on_step: bool = False,
         accumulate_on_cpu: bool = True,
-        calc_best_score_thresholds: bool = False,
+        calc_best_score_thresholds: bool = True,
         include_classwise_ap: bool = False,
         class_names: List[str] = None,
         state_dict_prefix: str = "",
@@ -139,7 +139,8 @@ class DetectionMetrics(Metric):
         self.calc_best_score_thresholds = calc_best_score_thresholds
         if self.calc_best_score_thresholds:
             self.component_names.append("Best_score_threshold")
-            self.component_names += [f"Best_score_threshold_cls_{i}" for i in range(self.num_cls)]
+            self.best_threshold_per_class_names = [f"Best_score_threshold_{class_name}" for class_name in class_names]
+            self.component_names += self.best_threshold_per_class_names
         self.components = len(self.component_names)
 
         self.post_prediction_callback = post_prediction_callback
@@ -197,39 +198,48 @@ class DetectionMetrics(Metric):
         """Compute the metrics for all the accumulated results.
         :return: Metrics of interest
         """
-        mean_ap, mean_precision, mean_recall, mean_f1, best_score_threshold, best_score_threshold_per_cls = -1.0, -1.0, -1.0, -1.0, -1.0, None
+        mean_ap, mean_precision, mean_recall, mean_f1, best_score_threshold = -1.0, -1.0, -1.0, -1.0, -1.0
         accumulated_matching_info = getattr(self, self.state_key)
+        best_score_threshold_per_cls = np.zeros(self.num_cls)
         mean_ap_per_class = np.zeros(self.num_cls)
 
         if len(accumulated_matching_info):
             matching_info_tensors = [torch.cat(x, 0) for x in list(zip(*accumulated_matching_info))]
 
             # shape (n_class, nb_iou_thresh)
-            ap, precision, recall, f1, unique_classes, best_score_threshold, best_score_threshold_per_cls = compute_detection_metrics(
+            (
+                ap_per_present_classes,
+                precision_per_present_classes,
+                recall_per_present_classes,
+                f1_per_present_classes,
+                present_classes,
+                best_score_threshold,
+                best_score_thresholds_per_present_classes,
+            ) = compute_detection_metrics(
                 *matching_info_tensors,
                 recall_thresholds=self.recall_thresholds,
                 score_threshold=self.score_threshold,
                 device="cpu" if self.accumulate_on_cpu else self.device,
-                calc_best_score_thresholds=self.calc_best_score_thresholds,
             )
 
             # Precision, recall and f1 are computed for IoU threshold range, averaged over classes
             # results before version 3.0.4 (Dec 11 2022) were computed only for smallest value (i.e IoU 0.5 if metric is @0.5:0.95)
-            mean_precision, mean_recall, mean_f1 = precision.mean(), recall.mean(), f1.mean()
+            mean_precision, mean_recall, mean_f1 = precision_per_present_classes.mean(), recall_per_present_classes.mean(), f1_per_present_classes.mean()
 
             # MaP is averaged over IoU thresholds and over classes
-            mean_ap = ap.mean()
+            mean_ap = ap_per_present_classes.mean()
 
             # Fill array of per-class AP scores with values for classes that were present in the dataset
-            ap_per_class = ap.mean(1)
-            for i, class_index in enumerate(unique_classes):
+            ap_per_class = ap_per_present_classes.mean(1)
+            for i, class_index in enumerate(present_classes):
                 mean_ap_per_class[class_index] = float(ap_per_class[i])
+                best_score_threshold_per_cls[class_index] = float(best_score_thresholds_per_present_classes[i])
 
         output_dict = {
-            self.precision_metric_key: mean_precision,
-            self.recall_metric_key: mean_recall,
-            self.map_metric_key: mean_ap,
-            self.f1_metric_key: mean_f1,
+            self.precision_metric_key: float(mean_precision),
+            self.recall_metric_key: float(mean_recall),
+            self.map_metric_key: float(mean_ap),
+            self.f1_metric_key: float(mean_f1),
         }
 
         if self.include_classwise_ap:
@@ -237,8 +247,12 @@ class DetectionMetrics(Metric):
                 output_dict[self.per_class_ap_names[i]] = float(ap_i)
 
         if self.calc_best_score_thresholds:
-            output_dict["Best_score_threshold"] = best_score_threshold
-            output_dict.update(best_score_threshold_per_cls)
+            output_dict["Best_score_threshold"] = float(best_score_threshold)
+
+        if self.include_classwise_ap and self.calc_best_score_thresholds:
+            for threshold_per_class_names, threshold_value in zip(self.best_threshold_per_class_names, best_score_threshold_per_cls):
+                output_dict[threshold_per_class_names] = float(threshold_value)
+
         return output_dict
 
     def _sync_dist(self, dist_sync_fn=None, process_group=None):
@@ -284,7 +298,7 @@ class DetectionMetricsDistanceBased(DetectionMetrics):
         top_k_predictions: int = 100,
         dist_sync_on_step: bool = False,
         accumulate_on_cpu: bool = True,
-        calc_best_score_thresholds: bool = False,
+        calc_best_score_thresholds: bool = True,
         include_classwise_ap: bool = False,
         class_names: List[str] = None,
     ):
@@ -363,7 +377,7 @@ class DetectionMetrics_050(DetectionMetrics):
         top_k_predictions: int = 100,
         dist_sync_on_step: bool = False,
         accumulate_on_cpu: bool = True,
-        calc_best_score_thresholds: bool = False,
+        calc_best_score_thresholds: bool = True,
         include_classwise_ap: bool = False,
         class_names: List[str] = None,
     ):
@@ -395,7 +409,7 @@ class DetectionMetrics_075(DetectionMetrics):
         top_k_predictions: int = 100,
         dist_sync_on_step: bool = False,
         accumulate_on_cpu: bool = True,
-        calc_best_score_thresholds: bool = False,
+        calc_best_score_thresholds: bool = True,
         include_classwise_ap: bool = False,
         class_names: List[str] = None,
     ):
@@ -427,7 +441,7 @@ class DetectionMetrics_050_095(DetectionMetrics):
         top_k_predictions: int = 100,
         dist_sync_on_step: bool = False,
         accumulate_on_cpu: bool = True,
-        calc_best_score_thresholds: bool = False,
+        calc_best_score_thresholds: bool = True,
         include_classwise_ap: bool = False,
         class_names: List[str] = None,
     ):

--- a/tests/unit_tests/detection_utils_test.py
+++ b/tests/unit_tests/detection_utils_test.py
@@ -9,9 +9,10 @@ from super_gradients.common.object_names import Models
 from super_gradients.training import utils as core_utils, models
 from super_gradients.training.dataloaders.dataloaders import coco2017_val
 from super_gradients.training.datasets.datasets_conf import COCO_DETECTION_CLASSES_LIST
+from super_gradients.training.datasets.pose_estimation_datasets.yolo_nas_pose_collate_fn import flat_collate_tensors_with_batch_index
 from super_gradients.training.metrics import DetectionMetrics, DetectionMetrics_050
 from super_gradients.training.models.detection_models.yolo_base import YoloXPostPredictionCallback
-from super_gradients.training.utils.detection_utils import DetectionVisualization
+from super_gradients.training.utils.detection_utils import DetectionVisualization, DetectionPostPredictionCallback, xyxy2cxcywh
 from tests.core_test_utils import is_data_available
 
 
@@ -21,9 +22,56 @@ class TestDetectionUtils(unittest.TestCase):
         self.model = models.get(Models.YOLOX_N, pretrained_weights="coco").to(self.device)
         self.model.eval()
 
+    def test_detection_metric_with_calc_best_score_thresholds(self):
+        class DummyCallback(DetectionPostPredictionCallback):
+            def forward(self, p, device=None):
+                return p
+
+        class_names = ["A", "B", "C"]
+        num_classes = len(class_names)
+        metric = DetectionMetrics(
+            num_cls=num_classes,
+            post_prediction_callback=DummyCallback(),
+            normalize_targets=True,
+            calc_best_score_thresholds=True,
+            include_classwise_ap=True,
+            class_names=class_names,
+        )
+
+        # x1, y1, x2, y2, confidence, class_label
+
+        num_predictions = 100
+        num_targets = 64
+        preds = torch.cat(
+            [
+                torch.randint(0, 100, (num_predictions, 2)),  # [x1,y1]
+                torch.randint(100, 200, (num_predictions, 2)),  # [x2,y2]
+                torch.randn((num_predictions, 1)).sigmoid(),
+                torch.randint(0, num_classes, (num_predictions, 1)),  # [x2,y2]
+            ],
+            dim=-1,
+        ).float()
+
+        targets = torch.cat(
+            [
+                torch.randint(0, num_classes, (num_targets, 1)),  # [x2,y2]
+                torch.randint(0, 100, (num_targets, 2)),  # [x1,y1]
+                torch.randint(100, 200, (num_targets, 2)),  # [x2,y2]
+            ],
+            dim=-1,
+        ).float()
+
+        targets[:, 1:] = xyxy2cxcywh(targets[:, 1:])
+        targets_flat = flat_collate_tensors_with_batch_index([targets])
+
+        metric(preds=[preds], target=targets_flat, device="cpu", inputs=torch.zeros((1, 3, 640, 640)))
+        metric_values = metric.compute()
+        self.assertTrue("Best_score_threshold" in metric_values)
+        for metric_value_name in metric.best_threshold_per_class_names:
+            self.assertTrue(metric_value_name in metric_values)
+
     @unittest.skipIf(not is_data_available(), "run only when /data is available")
     def test_visualization(self):
-
         with tempfile.TemporaryDirectory() as tmpdirname:
             valid_loader = coco2017_val(dataloader_params={"batch_size": 16, "num_workers": 0})
             post_prediction_callback = YoloXPostPredictionCallback()
@@ -47,7 +95,6 @@ class TestDetectionUtils(unittest.TestCase):
 
     @unittest.skipIf(not is_data_available(), "run only when /data is available")
     def test_detection_metrics(self):
-
         valid_loader = coco2017_val(dataloader_params={"batch_size": 16, "num_workers": 0})
 
         metrics = [


### PR DESCRIPTION
This PR changes the default value of `calc_best_score_thresholds` of `DetectionMetrics` and inheriting classes to `True` which adds additional metric value logged - an optimal confidence threshold value that maximized F1 score.

And as a bonus it fixes a bug in implementation of the metric to work correctly when custom class names are set.