### PR TITLE
changes logic from only one to exactly one parameter for step lr

### DIFF
--- a/src/super_gradients/training/utils/callbacks/callbacks.py
+++ b/src/super_gradients/training/utils/callbacks/callbacks.py
@@ -406,7 +406,7 @@ class StepLRScheduler(LRCallbackBase):
             )
 
         if step_lr_update_freq is None and len(lr_updates) == 0:
-            raise ValueError("At least one of [lr_updates, step_lr_update_freq] parameters should be passed" f" to {StepLRScheduler.__name__} constructor")
+            raise ValueError(f"At least one of [lr_updates, step_lr_update_freq] parameters should be passed to {StepLRScheduler.__name__} constructor")
 
         if step_lr_update_freq:
             max_epochs = self.training_params.max_epochs - self.training_params.lr_cooldown_epochs

--- a/src/super_gradients/training/utils/callbacks/callbacks.py
+++ b/src/super_gradients/training/utils/callbacks/callbacks.py
@@ -399,8 +399,8 @@ class StepLRScheduler(LRCallbackBase):
 
     def __init__(self, lr_updates, lr_decay_factor, step_lr_update_freq=None, **kwargs):
         super().__init__(Phase.TRAIN_EPOCH_END, **kwargs)
-        if step_lr_update_freq and len(lr_updates):
-            raise ValueError("Only one of [lr_updates, step_lr_update_freq] should be passed to StepLRScheduler constructor")
+        if not ((step_lr_update_freq is None) ^ (len(lr_updates) == 0)):
+            raise ValueError(f"Exactly one of [lr_updates, step_lr_update_freq] should be passed to {StepLRScheduler.__name__} constructor")
 
         if step_lr_update_freq:
             max_epochs = self.training_params.max_epochs - self.training_params.lr_cooldown_epochs

--- a/src/super_gradients/training/utils/callbacks/callbacks.py
+++ b/src/super_gradients/training/utils/callbacks/callbacks.py
@@ -399,8 +399,14 @@ class StepLRScheduler(LRCallbackBase):
 
     def __init__(self, lr_updates, lr_decay_factor, step_lr_update_freq=None, **kwargs):
         super().__init__(Phase.TRAIN_EPOCH_END, **kwargs)
-        if not ((step_lr_update_freq is None) ^ (len(lr_updates) == 0)):
-            raise ValueError(f"Exactly one of [lr_updates, step_lr_update_freq] should be passed to {StepLRScheduler.__name__} constructor")
+        if step_lr_update_freq and len(lr_updates):
+            raise ValueError(
+                "Parameters lr_updates and step_lr_update_freq are mutually exclusive"
+                f" and cannot be passed to {StepLRScheduler.__name__} constructor simultaneously"
+            )
+
+        if step_lr_update_freq is None and len(lr_updates) == 0:
+            raise ValueError("At least one of [lr_updates, step_lr_update_freq] parameters should be passed" f" to {StepLRScheduler.__name__} constructor")
 
         if step_lr_update_freq:
             max_epochs = self.training_params.max_epochs - self.training_params.lr_cooldown_epochs

--- a/tests/unit_tests/lr_warmup_test.py
+++ b/tests/unit_tests/lr_warmup_test.py
@@ -61,7 +61,7 @@ class LRWarmupTest(unittest.TestCase):
 
         train_params = {
             "max_epochs": 5,
-            "lr_updates": [],
+            "lr_updates": [10],
             "lr_decay_factor": 0.1,
             "lr_mode": "StepLRScheduler",
             "lr_warmup_epochs": 3,
@@ -189,7 +189,7 @@ class LRWarmupTest(unittest.TestCase):
 
         train_params = {
             "max_epochs": 5,
-            "lr_updates": [],
+            "lr_updates": [10],
             "lr_decay_factor": 0.1,
             "lr_mode": "StepLRScheduler",
             "lr_warmup_epochs": 3,
@@ -227,7 +227,7 @@ class LRWarmupTest(unittest.TestCase):
 
         train_params = {
             "max_epochs": 5,
-            "lr_updates": [],
+            "lr_updates": [10],
             "lr_decay_factor": 0.1,
             "lr_mode": "StepLRScheduler",
             "lr_warmup_epochs": 3,


### PR DESCRIPTION
This fix makes sure that either `lr_updates` contains something (non-empty list), or `step_lr_update_freq` exists, but not both.

In case where `lr_updates` is not set then it defaults to an empty list, which has no impact on the scheduler - but the code works -- not the best UX