### PR TITLE
Fix potential unwanted simplification of ONNX graph when exported model with random weights

### DIFF
--- a/src/super_gradients/modules/qarepvgg_block.py
+++ b/src/super_gradients/modules/qarepvgg_block.py
@@ -147,7 +147,14 @@ class QARepVGGBlock(nn.Module):
             self.identity = None
 
         if use_alpha:
-            self.alpha = torch.nn.Parameter(torch.tensor([1.0]), requires_grad=True)
+            # If we are using alpha, we need to add some noise to the initial value of 1
+            # When we are benchmarking the model we usually use random weights,
+            # so when ONNX simplifies the model it will remove multiplication of alpha * residual branch and
+            # replace it with simple addition (Since 1 * has no effect)
+            # To prevent this we add some noise to the initial value of alpha which prevents this from happening
+            # but since the noise is very small it should not affect the training process
+            noise = torch.randn((1,)) * 0.01
+            self.alpha = torch.nn.Parameter(torch.tensor([1.0]) + noise, requires_grad=True)
         else:
             self.alpha = 1.0
 


### PR DESCRIPTION
# Problem

A RepVGG block has default alpha value of 1. This parameter controls the scalar multiply factor for residual branch. During NAS benchmarking of the model usually done using randomly initialized weights.
In this case a default value of 1 is simplified by ONNX so operation `alpha * x` reduced to simple addition. Elimination of multiplication makes the benchmark result a bit too optimistic. 

After model has been trained this alpha most likely will have the value that is different from 1 and hence the graph will contain the multiplication.

# Solution

Adds a small noise to default value such that multiplication is not eliminated from the graph for model with random weights.