### PR TITLE
Added explicit antialias=False to ensure we can export torchvision Resize to ONNX

### DIFF
--- a/tests/unit_tests/export_onnx_test.py
+++ b/tests/unit_tests/export_onnx_test.py
@@ -12,7 +12,7 @@ from super_gradients.training.transforms import Standardize
 class TestModelsONNXExport(unittest.TestCase):
     def test_models_onnx_export_with_deprecated_input_shape(self):
         pretrained_model = models.get(Models.RESNET18, num_classes=1000, pretrained_weights="imagenet")
-        preprocess = Compose([Resize(224), Standardize(), Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])])
+        preprocess = Compose([Resize(224, antialias=False), Standardize(), Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])])
         with tempfile.TemporaryDirectory() as tmpdirname:
             out_path = os.path.join(tmpdirname, "resnet18.onnx")
             models.convert_to_onnx(model=pretrained_model, out_path=out_path, input_shape=(3, 256, 256), pre_process=preprocess)
@@ -20,7 +20,7 @@ class TestModelsONNXExport(unittest.TestCase):
 
     def test_models_onnx_export(self):
         pretrained_model = models.get(Models.RESNET18, num_classes=1000, pretrained_weights="imagenet")
-        preprocess = Compose([Resize(224), Standardize(), Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])])
+        preprocess = Compose([Resize(224, antialias=False), Standardize(), Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])])
         with tempfile.TemporaryDirectory() as tmpdirname:
             out_path = os.path.join(tmpdirname, "resnet18.onnx")
             models.convert_to_onnx(


### PR DESCRIPTION
In https://github.com/pytorch/vision/releases/tag/v0.17.0 release a default value of antialias argument was changed. New value is incompatible with ONNX models.
So this PR adds explicit old value to keep tests green