### PR TITLE
Added a class balanced distributed sampler

### DIFF
--- a/src/super_gradients/common/object_names.py
+++ b/src/super_gradients/common/object_names.py
@@ -194,6 +194,7 @@ class Samplers:
 
     REPEAT_AUG = "RepeatAugSampler"
     DISTRIBUTED = "DistributedSampler"
+    DISTRIBUTED_DETECTION_CLASS_BALANCING = "DistributedDetectionClassBalancingSampler"
     SEQUENTIAL = "SequentialSampler"
     SUBSET_RANDOM = "SubsetRandomSampler"
     RANDOM = "RandomSampler"

--- a/src/super_gradients/training/datasets/balancing_classes_utils.py
+++ b/src/super_gradients/training/datasets/balancing_classes_utils.py
@@ -1,0 +1,88 @@
+import math
+from typing import Callable, List, Optional
+
+import numpy as np
+from torch.utils.data import Dataset
+
+
+def _default_oversample_heuristic(cat_id, cat_freq, oversample_threshold):
+    """
+    How to oversample a category. This heuristic is based on https://arxiv.org/pdf/1908.03195.pdf.
+    A value of 1.0 corresponds to no oversampling.
+    """
+    return max(1.0, math.sqrt(oversample_threshold / cat_freq))
+
+
+def get_repeat_factors(
+    *,
+    index_to_classes: Callable[[int], List[int]],
+    num_classes: int,
+    dataset_length: int,
+    ignore_empty_annotations: bool = False,
+    oversample_threshold: Optional[float] = None,
+    oversample_heuristic: Optional[Callable[[int, int, float], float]] = _default_oversample_heuristic,
+) -> List[float]:
+    """
+    Oversampling scarce classes from detection dataset, following sampling strategy described in https://arxiv.org/pdf/1908.03195.pdf.
+    Implementation based on https://github.com/open-mmlab/mmdetection (Apache 2.0 license).
+
+    :param index_to_classes: A function that maps an index to a list of classes (labels).
+    :param num_classes: Number of classes.
+    :param dataset_length: Length of the dataset.
+    :param ignore_empty_annotations: Whether to ignore empty annotations.
+    :param oversample_threshold: A frequency threshold (fraction, 0-1). Classes that are *less frequent* than this threshold will be oversampled.
+                                    Default: None. If None, the median of the class frequencies will be used.
+                                    See step (1) below to understand how frequencies are computed.
+
+
+    The repeat factor is computed as followed.
+    1. For each category c, compute the fraction # of images that contain it (its frequency): :math:`f(c)`
+    2. For each category c, compute the category-level repeat factor: :math:`r(c) = max(1, sqrt(t/f(c)))`
+    3. For each image I, compute the image-level repeat factor: :math:`r(I) = max_{c in I} r(c)`
+
+    Returns a list of repeat factors (length = dataset_length). How to read: result[i] is a float, indicates the repeat factor of image i.
+    """
+
+    # 0. pre-fetch the categories to reduce time
+    sample_id_to_categories = {idx: index_to_classes(idx) for idx in range(dataset_length)}
+
+    # 1. For each category c, compute the fraction # of images that contain it: f(c)
+    category_freq = dict()
+    for idx in range(dataset_length):
+        cat_ids = sample_id_to_categories[idx]
+        if len(cat_ids) == 0 and not ignore_empty_annotations:
+            cat_ids = {num_classes}
+        for cat_id in cat_ids:
+            category_freq[cat_id] = category_freq.get(cat_id, 0) + 1
+    for k, v in category_freq.items():
+        category_freq[k] = v / dataset_length
+
+    # 2. For each category c, compute the category-level repeat factor: r(c) = max(1, sqrt(t/f(c)))
+    if oversample_threshold is None:
+        oversample_threshold = np.median(list(category_freq.values()))
+    category_repeat = {cat_id: oversample_heuristic(cat_id, cat_freq, oversample_threshold) for cat_id, cat_freq in category_freq.items()}
+
+    # 3. For each image I, compute the image-level repeat factor: r(I) = max_{c in I} r(c)
+    repeat_factors = []
+    for idx in range(dataset_length):
+        cat_ids = sample_id_to_categories[idx]
+        if len(cat_ids) == 0:  # no annotations for this image
+            repeat_factors.append(1.0 * (not ignore_empty_annotations))  # 0.0 if we ignore, 1.0 otherwise. We are not oversampling empty annotations.
+            continue
+        repeat_factor = max({category_repeat[cat_id] for cat_id in cat_ids})
+        repeat_factors.append(repeat_factor)
+
+    return repeat_factors
+
+
+class IndexMappingDatasetWrapper(Dataset):
+    def __init__(self, dataset: Dataset, mapping: List[int]):
+        super().__init__()
+        self.dataset = dataset
+        self.mapping = mapping
+
+    def __getitem__(self, item):
+        return self.dataset[self.mapping[item]]
+
+    def __len__(self):
+        return len(self.mapping)

--- a/src/super_gradients/training/datasets/detection_datasets/detection_dataset_class_balancing_wrapper.py
+++ b/src/super_gradients/training/datasets/detection_datasets/detection_dataset_class_balancing_wrapper.py
@@ -1,0 +1,34 @@
+import math
+from functools import partial
+from typing import Optional, List
+from torch.utils.data import DistributedSampler
+
+from super_gradients.common.object_names import Samplers
+from super_gradients.common.registry import register_sampler
+from super_gradients.training.datasets import DetectionDataset
+from super_gradients.training.datasets.balancing_classes_utils import get_repeat_factors, IndexMappingDatasetWrapper
+
+
+def extract_labels_from_target(dataset: DetectionDataset, idx: int) -> List[int]:
+    return dataset._load_sample_annotation(idx)["target"][:, -1]
+
+
+@register_sampler(Samplers.DISTRIBUTED_DETECTION_CLASS_BALANCING)
+class DetectionClassBalancedDistributedSampler(DistributedSampler):
+    """
+    DetectionClassBalancedDistributedSampler is a distributed sampler that over-samples scarce classes in detection datasets.
+    """
+
+    def __init__(self, dataset: DetectionDataset, oversample_threshold: Optional[float] = None, *args, **kwargs) -> None:
+        repeat_factors = get_repeat_factors(
+            index_to_classes=partial(extract_labels_from_target, dataset),
+            num_classes=len(dataset._all_classes),
+            dataset_length=len(dataset),
+            ignore_empty_annotations=dataset.ignore_empty_annotations,
+            oversample_threshold=oversample_threshold,
+        )
+        repeat_indices = []
+        for dataset_idx, repeat_factor in enumerate(repeat_factors):
+            repeat_indices.extend([dataset_idx] * math.ceil(repeat_factor))
+
+        super().__init__(dataset=IndexMappingDatasetWrapper(dataset, repeat_indices), *args, **kwargs)

--- a/tests/unit_tests/class_balancing_test.py
+++ b/tests/unit_tests/class_balancing_test.py
@@ -1,0 +1,110 @@
+import numpy as np
+import torch
+import unittest
+
+from torch.utils.data import Dataset
+
+from super_gradients.training.datasets.balancing_classes_utils import get_repeat_factors
+
+
+class SingleLabelUnbalancedDataset(Dataset):
+    def __init__(self, num_classes: int) -> None:
+        super().__init__()
+        self.num_classes = num_classes
+        self.ignore_empty_annotations = False
+
+    def __len__(self) -> int:
+        return self.num_classes
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        return torch.tensor([idx] * idx)  # no class 0
+
+
+class MultiLabelUnbalancedDataset(Dataset):
+    def __init__(self, num_classes: int) -> None:
+        super().__init__()
+        self.num_classes = num_classes
+        self.ignore_empty_annotations = False
+
+    def __len__(self) -> int:
+        return self.num_classes
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        return torch.tensor([idx, 0])  # class 0 appears everywhere, other classes appear only once.
+
+
+class ClassBalancingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.single_label_dataset = SingleLabelUnbalancedDataset(num_classes=5)  # [[], [1], [2,2], [3,3,3], [4,4,4,4]]
+        self.multi_label_dataset = MultiLabelUnbalancedDataset(num_classes=5)  # [[0,0], [1,0], [2,0], [3,0], [4,0]]
+
+    def test_without_oversampling(self):
+        repeat_factors = get_repeat_factors(
+            index_to_classes=lambda idx: self.single_label_dataset[idx].tolist(),
+            num_classes=self.single_label_dataset.num_classes,
+            dataset_length=len(self.single_label_dataset),
+            ignore_empty_annotations=self.single_label_dataset.ignore_empty_annotations,
+            oversample_threshold=0.0,
+        )
+        expected_mappings = [1.0] * len(self.single_label_dataset)
+        self.assertListEqual(expected_mappings, repeat_factors)
+
+    def test_oversampling_frequent_classes_less_often_than_scarce(self):
+        repeat_factors = get_repeat_factors(
+            index_to_classes=lambda idx: self.single_label_dataset[idx].tolist(),
+            num_classes=self.single_label_dataset.num_classes,
+            dataset_length=len(self.single_label_dataset),
+            ignore_empty_annotations=self.single_label_dataset.ignore_empty_annotations,
+            oversample_threshold=1.0,
+        )
+
+        # reminder: samples = [[], [1], [2,2], [3,3,3], [4,4,4,4]]
+        self.assertEqual(repeat_factors[0], 1.0)  # do not over sample empty annotations
+
+        # expected something like [1.0, a, b, c, d], a>b>c>d>1.0
+        diffs = np.diff(repeat_factors[1:])
+        self.assertTrue(np.all(diffs < 0.0))
+
+    def test_multi_class_over_sampling(self):
+        """
+        Interestingly, when we have a class that appears in every sample ([[0,0], [1,0], [2,0], [3,0], [4,0]]),
+        and other samples have the same frequencies, we are still oversampling samples, but use the same repeat factor for all.
+        The reason is that originally we have #0 class appearing 6 times, and other classes appear 1 time, which is 6x freq; after resampling,
+        we have #0 class appearing 14 times, and other classes appear 3 times. Note that lower bound for class #0 is 4x freq, and after resampling it is 4.6x.
+        """
+        repeat_factors = get_repeat_factors(
+            index_to_classes=lambda idx: self.multi_label_dataset[idx].tolist(),
+            num_classes=self.multi_label_dataset.num_classes,
+            dataset_length=len(self.multi_label_dataset),
+            ignore_empty_annotations=self.multi_label_dataset.ignore_empty_annotations,
+            oversample_threshold=1.0,
+        )
+
+        # reminder: samples = [[0,0], [1,0], [2,0], [3,0], [4,0]]
+        self.assertEqual(repeat_factors[0], 1.0)  # do not over sample the biggest class
+
+        # expected something like [1.0, a, b, c, d], a=b=c=d>1.0
+        diffs = np.diff(repeat_factors[1:])
+        self.assertTrue(np.all(diffs == 0.0))
+
+    def test_no_oversample_below_threshold(self):
+        repeat_factors = get_repeat_factors(
+            index_to_classes=lambda idx: self.single_label_dataset[idx].tolist(),
+            num_classes=self.single_label_dataset.num_classes,
+            dataset_length=len(self.single_label_dataset),
+            ignore_empty_annotations=self.single_label_dataset.ignore_empty_annotations,
+            oversample_threshold=0.5,
+        )
+
+        # reminder: samples = [[], [1], [2,2], [3,3,3], [4,4,4,4]]
+        # overall we have 5 images, class #1 appears 1/5 (in image 1), #2 appears 2/5 (image 2), #3 appears 3/5 (image 3), #4 appears 4/5 (image 4).
+        # We will not oversample IMAGES 3 and 4, nor the empty image 0.
+        oversampled_indices = np.array([False, True, True, False, False])
+        self.assertTrue(np.all(np.array(repeat_factors)[~oversampled_indices] == 1.0))  # all
+
+        # make sure indices that are oversampled are with expected repeat factor
+        self.assertTrue(np.all(np.diff(np.array(repeat_factors)[oversampled_indices]) < 0.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/dataset_index_mapping_test.py
+++ b/tests/unit_tests/dataset_index_mapping_test.py
@@ -1,0 +1,42 @@
+import torch
+import unittest
+
+from torch.utils.data import Dataset
+
+from super_gradients.training.datasets.balancing_classes_utils import IndexMappingDatasetWrapper
+
+
+class DummyDataset(Dataset):
+    def __init__(self, num_classes: int) -> None:
+        super().__init__()
+        self.num_classes = num_classes
+        self.ignore_empty_annotations = False
+
+    def __len__(self) -> int:
+        return self.num_classes
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        return torch.tensor(idx)
+
+
+class DatasetIndexMappingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dummy_dataset = DummyDataset(num_classes=5)
+
+    def test_mapping_indices_that_does_nothing(self):
+        wrapper = IndexMappingDatasetWrapper(self.dummy_dataset, list(range(len(self.dummy_dataset))))
+        self.assertEqual(len(wrapper), len(self.dummy_dataset))
+        for i in range(len(wrapper)):
+            self.assertEqual(self.dummy_dataset[i], wrapper[i])
+
+    def test_mapping_indices_that_samples_only_specific_index(self):
+        c = 3
+        i = 1
+        mapping = [i] * c
+        wrapper = IndexMappingDatasetWrapper(self.dummy_dataset, mapping)
+        for j in range(len(wrapper)):
+            self.assertEqual(self.dummy_dataset[i], wrapper[j])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/detection_class_balancing_distributed_sampler_test.py
+++ b/tests/unit_tests/detection_class_balancing_distributed_sampler_test.py
@@ -1,0 +1,109 @@
+import random
+from typing import Dict, Union, Any
+
+import numpy as np
+import torch
+import unittest
+
+from torch.utils.data import Dataset
+
+from super_gradients.training.datasets.detection_datasets.detection_dataset_class_balancing_wrapper import DetectionClassBalancedDistributedSampler
+
+
+class DummyDetectionDataset(Dataset):  # NOTE: we implement the needed stuff from DetectionDataset, but we do not inherit it because the ctor is massive
+    def __init__(self, class_id_to_frequency: Dict[int, int], total_samples: int) -> None:
+        self.total_samples = total_samples
+        self.num_classes = len(class_id_to_frequency)
+        self.class_id_to_frequency = class_id_to_frequency
+        self.ignore_empty_annotations = True
+        self._setup_data_source()
+        super().__init__()
+
+    @property
+    def _all_classes(self):
+        return [f"class_{i}" for i in range(self.num_classes)]
+
+    def _setup_data_source(self) -> int:
+        flattened_list = list()
+        for k, v in self.class_id_to_frequency.items():
+            flattened_list.extend([k] * v)
+
+        random.shuffle(flattened_list)
+
+        self.idx_to_classes = np.array_split(flattened_list, self.total_samples)
+        return len(self.idx_to_classes)
+
+    def _load_sample_annotation(self, sample_id: int) -> Dict[str, Union[np.ndarray, Any]]:
+        targets = self.idx_to_classes[sample_id][..., np.newaxis]
+        return {"image_path": "dummy.png", "target": targets}
+
+    def __len__(self) -> int:
+        return len(self.idx_to_classes)
+
+    def __getitem__(self, idx: int):
+        return torch.rand(1, 3, 16, 16), self._load_sample_annotation(idx)["target"]
+
+
+class DatasetIndexMappingTest(unittest.TestCase):
+    def test_balancing_classes_that_are_with_same_frequency(self):
+        id_to_freq = {0: 10, 1: 10, 2: 10}
+        n_samplers = 2
+        n_samples = n_samplers * 7
+        dataset = DummyDetectionDataset(class_id_to_frequency=id_to_freq, total_samples=n_samples)
+
+        samplers = [
+            DetectionClassBalancedDistributedSampler(
+                dataset=dataset,  # noqa
+                oversample_threshold=None,
+                shuffle=False,
+                num_replicas=2,
+                rank=r,
+                drop_last=False,  # requires len(dataset) % num_replicas == 0
+            )
+            for r in [0, 1]
+        ]
+
+        indices_sampled = []
+
+        for sampler in samplers:
+            for sample in sampler:
+                indices_sampled.append(sample)
+
+        self.assertSetEqual(set(indices_sampled), set(range(n_samples)))  # we sampled uniformly all the indices
+
+    def test_balancing_scarce_classes(self):
+        id_to_freq = {0: 10, 1: 3, 2: 10}  # class 1 is scarce, appears 3 / 20. Other classes are 10/20.
+        n_samplers = 2
+        n_samples = n_samplers * 10
+        dataset = DummyDetectionDataset(class_id_to_frequency=id_to_freq, total_samples=n_samples)
+
+        samplers = [
+            DetectionClassBalancedDistributedSampler(
+                dataset=dataset,
+                oversample_threshold=None,
+                shuffle=False,
+                num_replicas=2,
+                rank=r,
+                drop_last=False,  # requires len(dataset) % num_replicas == 0
+            )
+            for r in [0, 1]
+        ]
+
+        indices_sampled = []
+
+        for sampler in samplers:
+            for sampled_idx in sampler:
+                indices_sampled.append(sampled_idx)
+
+        new_distribution = {0: 0, 1: 0, 2: 0}
+        for i in indices_sampled:
+            _, labels = samplers[0].dataset[i]  # can't use dataset[i] because we wrap it with oversampling mapping
+            for label in labels:
+                new_distribution[int(label)] += 1
+
+        self.assertTrue(len(indices_sampled) > n_samples)
+        self.assertTrue(new_distribution[1] / len(indices_sampled) > id_to_freq[1] / n_samples)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Context:** in cases where some classes are less frequent than others, we'd want to sample images containing these classes more often.

**Current implementation:**
1. `IndexMappingDatasetWrapper` - gets a dataset and a list of indices (`mapping`), and wraps the dataset: `wrapper[i] == self.dataset[self.mapping[item]]`
2. An implementation of https://arxiv.org/pdf/1908.03195.pdf, that returns a float per index (image) indicating the scarcity of classes that are in that image (larger = more scarce = repeat it more often).
3. `DetectionClassBalancedDistributedSampler` that uses (1) with (2) for Detection datasets.

**Discussion:**
Current implementation supports distributed mode. Non-distributed mode can also be supported, but will result more code.
Some alternative implementations I can spot:
1. Do not wrap original dataset, but rather override `__iter__` from `DistributedSampler` - it is possible, however, causes coupling and code duplication. Current impelentation (`super().__init__(dataset=IndexMappingDatasetWrapper(dataset, repeat_indices), *args, **kwargs)`) is a bit less verbose.
2. Eventually, we might use `WeightedSampler`, however, it is not supported in distributed mode. There are some implementations of `DistributedWeightedSampler` in-the-wild. We can try these.
3. Perhaps we should consider a different approach where the heavy lifting is on the dataset size. For example:
    ```yaml:
    dataset: class_balanced_wrapper
       inner_dataset: coco
       ...
    ```
    The issue, however, is that we cannot inherit `inner_class`, no inherit `DetectionDataset` because we don't want to pass all the `__init__` parameters.
 4. Another option is to modify `DetectionDataset` and add a parameter for class balancing (i.e., `oversampling_threshold`) and do the heavy lifting inside `DetectionDataset`. This is less verbose, however, adds more responsibility to `DetectionDataset` (compared to Composition)


Open for discussion :)