### PR TITLE
Feature/sg 000 fix yolo nas scores

### DIFF
--- a/src/super_gradients/training/datasets/detection_datasets/coco_format_detection.py
+++ b/src/super_gradients/training/datasets/detection_datasets/coco_format_detection.py
@@ -145,9 +145,10 @@ class COCOFormatDetectionDataset(DetectionDataset):
             resized_img_shape = (int(height * scale_factor), int(width * scale_factor))
         else:
             resized_img_shape = initial_img_shape
+            scale_factor = 1
 
-        targets = np.concatenate([boxes_xyxy[~iscrowd], labels[~iscrowd, None]], axis=1).astype(np.float32)
-        crowd_targets = np.concatenate([boxes_xyxy[iscrowd], labels[iscrowd, None]], axis=1).astype(np.float32)
+        targets = np.concatenate([boxes_xyxy[~iscrowd] * scale_factor, labels[~iscrowd, None]], axis=1).astype(np.float32)
+        crowd_targets = np.concatenate([boxes_xyxy[iscrowd] * scale_factor, labels[iscrowd, None]], axis=1).astype(np.float32)
 
         annotation = {
             "target": targets,

--- a/src/super_gradients/training/datasets/detection_datasets/coco_format_detection.py
+++ b/src/super_gradients/training/datasets/detection_datasets/coco_format_detection.py
@@ -161,6 +161,7 @@ class COCOFormatDetectionDataset(DetectionDataset):
 
 @dataclasses.dataclass
 class DetectionAnnotation:
+    image_id: int
     image_path: str
     image_width: int
     image_height: int
@@ -276,6 +277,7 @@ def parse_coco_into_detection_annotations(
             image_path = os.path.join(image_path_prefix, image_path)
 
         ann = DetectionAnnotation(
+            image_id=img_id,
             image_path=image_path,
             image_width=image_width,
             image_height=image_height,

--- a/tests/integration_tests/yolo_nas_integration_test.py
+++ b/tests/integration_tests/yolo_nas_integration_test.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from super_gradients.training import models
 from super_gradients.training.dataloaders import coco2017_val_yolo_nas
@@ -7,10 +8,13 @@ from super_gradients.training.models.detection_models.pp_yolo_e import PPYoloEPo
 
 
 class YoloNASIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        self.data_dir = os.environ.get("SUPER_GRADIENTS_COCO_DATASET_DIR", "/data/coco")
+
     def test_yolo_nas_s_coco(self):
         trainer = Trainer("test_yolo_nas_s")
         model = models.get("yolo_nas_s", num_classes=80, pretrained_weights="coco")
-        dl = coco2017_val_yolo_nas()
+        dl = coco2017_val_yolo_nas(dataset_params=dict(data_dir=self.data_dir))
         metric = DetectionMetrics(
             normalize_targets=True,
             post_prediction_callback=PPYoloEPostPredictionCallback(score_threshold=0.03, nms_top_k=1000, max_predictions=300, nms_threshold=0.65),
@@ -22,7 +26,7 @@ class YoloNASIntegrationTest(unittest.TestCase):
     def test_yolo_nas_m_coco(self):
         trainer = Trainer("test_yolo_nas_m")
         model = models.get("yolo_nas_m", num_classes=80, pretrained_weights="coco")
-        dl = coco2017_val_yolo_nas()
+        dl = coco2017_val_yolo_nas(dataset_params=dict(data_dir=self.data_dir))
         metric = DetectionMetrics(
             normalize_targets=True,
             post_prediction_callback=PPYoloEPostPredictionCallback(score_threshold=0.03, nms_top_k=1000, max_predictions=300, nms_threshold=0.65),
@@ -34,7 +38,7 @@ class YoloNASIntegrationTest(unittest.TestCase):
     def test_yolo_nas_l_coco(self):
         trainer = Trainer("test_yolo_nas_l")
         model = models.get("yolo_nas_l", num_classes=80, pretrained_weights="coco")
-        dl = coco2017_val_yolo_nas()
+        dl = coco2017_val_yolo_nas(dataset_params=dict(data_dir=self.data_dir))
         metric = DetectionMetrics(
             normalize_targets=True,
             post_prediction_callback=PPYoloEPostPredictionCallback(score_threshold=0.03, nms_top_k=1000, max_predictions=300, nms_threshold=0.65),


### PR DESCRIPTION
Fixed bug introduced in #1791 that did not scale bbox coordinates when `input_dim` argument for dataset was set.