### PR TITLE
Removed unsused pyparsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ onnxruntime==1.15.0
 onnx==1.15.0
 pillow>=10.2.0
 pip-tools>=6.12.1
-pyparsing==2.4.5
 einops==0.3.2
 protobuf==3.20.3
 treelib==1.6.1


### PR DESCRIPTION
* Conflict when installing dvc. It requires a more recent version
* Package is no longer used in the project and originates from old version

Like said in [this old PR](https://github.com/Deci-AI/super-gradients/pull/1923) with @BloodAxe , I removed the pyparsing from requirements and updated the commit following the contribution guidelines