### PR TITLE
Added imagesize dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ albumentations~=1.3
 fonttools>=4.43.0
 # not directly required, pinned by Snyk to avoid a vulnerability
 werkzeug>=2.3.8
+imagesize~=1.4.1


### PR DESCRIPTION
After merging https://github.com/Deci-AI/super-gradients/pull/1946 an issue popped up with missing `imagesize` dependency in Yolo format dataset.
Probably it came as a bonus from `sphinx`. Since `sphinx` is not with us anymore `imagesize` was not installed and caused test to fail. Added latest `imagesize` dependency