### PR TITLE
OpenVINO-friendly heads  for YoloNAS & YoloNAS-Pose

### DIFF
--- a/src/super_gradients/training/models/detection_models/yolo_nas/dfl_heads.py
+++ b/src/super_gradients/training/models/detection_models/yolo_nas/dfl_heads.py
@@ -207,7 +207,12 @@ class NDFLHeads(BaseDetectionModule, SupportsReplaceNumClasses):
             reg_distri_list.append(torch.permute(reg_distri.flatten(2), [0, 2, 1]))
 
             reg_dist_reduced = torch.permute(reg_distri.reshape([-1, 4, self.reg_max + 1, height_mul_width]), [0, 2, 3, 1])
-            reg_dist_reduced = torch.nn.functional.conv2d(torch.nn.functional.softmax(reg_dist_reduced, dim=1), weight=self.proj_conv).squeeze(1)
+
+            # OpenVINO cannot handle this:
+            # reg_dist_reduced = torch.nn.functional.conv2d(torch.nn.functional.softmax(reg_dist_reduced, dim=1), weight=self.proj_conv).squeeze(1)
+            # So we do it with multiplication instead
+            reg_dist_reduced = torch.nn.functional.softmax(reg_dist_reduced, dim=1) * self.proj_conv
+            reg_dist_reduced = reg_dist_reduced.sum(dim=1, keepdim=False)
 
             # cls and reg
             cls_score_list.append(cls_logit.reshape([b, self.num_classes, height_mul_width]))

--- a/src/super_gradients/training/models/pose_estimation_models/yolo_nas_pose/yolo_nas_pose_ndfl_heads.py
+++ b/src/super_gradients/training/models/pose_estimation_models/yolo_nas_pose/yolo_nas_pose_ndfl_heads.py
@@ -150,7 +150,10 @@ class YoloNASPoseNDFLHeads(BaseDetectionModule, SupportsReplaceNumClasses):
             reg_distri_list.append(torch.permute(reg_distri.flatten(2), [0, 2, 1]))
 
             reg_dist_reduced = torch.permute(reg_distri.reshape([-1, 4, self.reg_max + 1, height_mul_width]), [0, 2, 3, 1])
-            reg_dist_reduced = torch.nn.functional.conv2d(torch.nn.functional.softmax(reg_dist_reduced, dim=1), weight=self.proj_conv).squeeze(1)
+            # OpenVINO cannot handle this:
+            # reg_dist_reduced = torch.nn.functional.conv2d(torch.nn.functional.softmax(reg_dist_reduced, dim=1), weight=self.proj_conv).squeeze(1)
+            # So we do it with multiplication instead
+            reg_dist_reduced = torch.nn.functional.softmax(reg_dist_reduced, dim=1).mul(self.proj_conv).sum(1)
 
             # cls and reg
             cls_score_list.append(cls_logit.reshape([b, -1, height_mul_width]))


### PR DESCRIPTION
It seems existing call to `F.conv2d` to compute weighted sum of box size distributions predictions confuses OpenVINO quantizers. This PR replaces this operation with simple multiplication which is equivalent op and works well for both TRT & Vino.