### PR TITLE
2X training speed improvement: prefetch next batch from the data loader while running current batch

### DIFF
--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -116,31 +116,6 @@ from super_gradients.training.utils.export_utils import infer_image_shape_from_m
 
 logger = get_logger(__name__)
 
-class PrefetchIterable:
-    def __init__(self, iterable):
-        self.iterable = iterable
-
-    def __iter__(self):
-        import concurrent.futures
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-
-        try:
-            iterator = iter(self.iterable)
-
-            def _prefetch():
-                return next(iterator)
-
-            prefetch_future = executor.submit(_prefetch)
-            while True:
-                try:
-                    value = prefetch_future.result()
-                except StopIteration:
-                    return
-                prefetch_future = executor.submit(_prefetch)
-                yield value
-
-        finally:
-            executor.shutdown()
 
 class PrefetchIterable:
     def __init__(self, iterable):

--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -5,6 +5,7 @@ import typing
 import warnings
 from copy import deepcopy
 from typing import Union, Tuple, Mapping, Dict, Any, List, Optional
+import concurrent.futures
 
 import hydra
 import numpy as np
@@ -115,12 +116,12 @@ from super_gradients.training.utils.export_utils import infer_image_shape_from_m
 
 logger = get_logger(__name__)
 
+
 class PrefetchIterable:
     def __init__(self, iterable):
         self.iterable = iterable
 
     def __iter__(self):
-        import concurrent.futures
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
         try:
@@ -140,6 +141,7 @@ class PrefetchIterable:
 
         finally:
             executor.shutdown()
+
 
 class Trainer:
     """


### PR DESCRIPTION
This improves my training speed by 2x. This fetches the next batch of images while processing the current batch. Results may vary based on system.

My setup:
2x NVIDIA 4090 
10900k
64GB RAM
M.2 Storage for coco dataset

Epoch time: 34 minutes to 14 minutes.