### PR TITLE
Fixed issue of logging hydra-instantiated config

### DIFF
--- a/src/super_gradients/training/sg_trainer/sg_trainer.py
+++ b/src/super_gradients/training/sg_trainer/sg_trainer.py
@@ -239,12 +239,14 @@ class Trainer:
         :return: the model and the output of trainer.train(...) (i.e results tuple)
         """
 
-        # TODO: bind checkpoint_run_id
         setup_device(
             device=core_utils.get_param(cfg, "device"),
             multi_gpu=core_utils.get_param(cfg, "multi_gpu"),
             num_gpus=core_utils.get_param(cfg, "num_gpus"),
         )
+
+        # Create resolved config before instantiation
+        recipe_logged_cfg = {"recipe_config": OmegaConf.to_container(cfg, resolve=True)}
 
         # INSTANTIATE ALL OBJECTS IN CFG
         cfg = hydra.utils.instantiate(cfg)
@@ -283,7 +285,6 @@ class Trainer:
 
         test_loaders = maybe_instantiate_test_loaders(cfg)
 
-        recipe_logged_cfg = {"recipe_config": OmegaConf.to_container(cfg, resolve=True)}
         # TRAIN
         res = trainer.train(
             model=model,


### PR DESCRIPTION
This PR fixes an issue in logging of train config object.
For logging we want non-instantiated config to be logged, so the fix is to resolve config first and retain this copy for logging and then instantiate it.

Reference: https://github.com/Deci-AI/super-gradients/issues/1986