### PR TITLE
Added explicit utf-8 encoding parameter to write methods

### DIFF
--- a/src/super_gradients/common/auto_logging/auto_logger.py
+++ b/src/super_gradients/common/auto_logging/auto_logger.py
@@ -52,7 +52,7 @@ class AutoLoggerConfig:
 
         if copy_already_logged_messages and self.filename is not None and os.path.exists(self.filename):
             with open(self.filename, "r", encoding="utf-8") as src:
-                with open(filename, "w") as dst:
+                with open(filename, "w", encoding="utf-8") as dst:
                     dst.write(src.read())
 
         file_logging_level = log_level or env_variables.FILE_LOG_LEVEL

--- a/src/super_gradients/common/plugins/deci_client.py
+++ b/src/super_gradients/common/plugins/deci_client.py
@@ -161,7 +161,7 @@ class DeciClient:
             zipfile.extractall(package_path)
 
         # add an init file that imports all code files
-        with open(os.path.join(package_path, "__init__.py"), "w") as init_file:
+        with open(os.path.join(package_path, "__init__.py"), "w", encoding="utf-8") as init_file:
             all_str = "\n\n__all__ = ["
             for code_file in os.listdir(path=package_path):
                 if code_file.endswith(".py") and not code_file.startswith("__init__"):

--- a/src/super_gradients/common/sg_loggers/base_sg_logger.py
+++ b/src/super_gradients/common/sg_loggers/base_sg_logger.py
@@ -156,7 +156,7 @@ class BaseSGLogger(AbstractSGLogger):
 
     @multi_process_safe
     def _write_to_log_file(self, lines: list):
-        with open(self.experiment_log_path, "a" if os.path.exists(self.experiment_log_path) else "w") as log_file:
+        with open(self.experiment_log_path, "a" if os.path.exists(self.experiment_log_path) else "w", encoding="utf-8") as log_file:
             for line in lines:
                 log_file.write(line + "\n")
 
@@ -345,7 +345,7 @@ class BaseSGLogger(AbstractSGLogger):
                 name = name + ".py"
 
             path = os.path.join(self._local_dir, name)
-            with open(path, "w") as f:
+            with open(path, "w", encoding="utf-8") as f:
                 f.write(code)
 
             self.add_file(name)

--- a/src/super_gradients/convert_recipe_to_code.py
+++ b/src/super_gradients/convert_recipe_to_code.py
@@ -311,7 +311,7 @@ if __name__ == "__main__":
         key_to_replace_with = f"{key}"
         content = content.replace(key_to_search, key_to_replace_with)
 
-    with open(output_script_path, "w") as f:
+    with open(output_script_path, "w", encoding="utf-8") as f:
         black = try_import_black()
         if black is not None:
             content = black.format_str(content, mode=black.FileMode(line_length=160))

--- a/src/super_gradients/training/datasets/detection_datasets/pascal_voc_detection.py
+++ b/src/super_gradients/training/datasets/detection_datasets/pascal_voc_detection.py
@@ -166,7 +166,7 @@ class PascalVOCDetectionDataset(PascalVOCFormatDetectionDataset):
                     xmin, ymin, xmax, ymax = get_coord("xmin"), get_coord("ymin"), get_coord("xmax"), get_coord("ymax")
                     labels.append(" ".join([xmin, ymin, xmax, ymax, str(PASCAL_VOC_2012_CLASSES_LIST.index(cls))]))
 
-            with open(new_label_path, "w") as f:
+            with open(new_label_path, "w", encoding="utf-8") as f:
                 f.write("\n".join(labels))
 
         urls = [

--- a/src/super_gradients/training/datasets/samplers/class_balanced_sampler.py
+++ b/src/super_gradients/training/datasets/samplers/class_balanced_sampler.py
@@ -100,7 +100,7 @@ class ClassBalancer:
 
         str_repeat_factors = [np.format_float_positional(rf, trim="0", precision=4) for rf in repeat_factors]
 
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(str_repeat_factors, f)
 
     @staticmethod

--- a/tests/unit_tests/export_detection_model_test.py
+++ b/tests/unit_tests/export_detection_model_test.py
@@ -568,7 +568,7 @@ class TestDetectionModelExport(unittest.TestCase):
         os.makedirs(export_dir, exist_ok=True)
 
         benchmark_command_dir = "benchmark_command.sh"
-        with open(benchmark_command_dir, "w") as f:
+        with open(benchmark_command_dir, "w", encoding="utf-8") as f:
             pass
 
         for output_predictions_format in [DetectionOutputFormatMode.BATCH_FORMAT, DetectionOutputFormatMode.FLAT_FORMAT]:

--- a/tests/unit_tests/pose_estimation_metrics_test.py
+++ b/tests/unit_tests/pose_estimation_metrics_test.py
@@ -87,7 +87,7 @@ class TestPoseEstimationMetrics(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             res_file = os.path.join(td, "keypoints_coco2017_results.json")
 
-            with open(res_file, "w") as f:
+            with open(res_file, "w", encoding="utf-8") as f:
                 json.dump(coco_pred, f, sort_keys=True, indent=4)
 
             coco_dt = self._load_coco_groundtruth(with_crowd, with_duplicates, with_invisible_keypoitns)

--- a/utils_script/create_sub_coco.py
+++ b/utils_script/create_sub_coco.py
@@ -46,7 +46,7 @@ def _copy_to_new_dir(mode: str, n_images: int, input_data_dir: Path, dest_data_d
     dest_images_dir = dest_data_dir / "images" / f"{mode}2017"
     dest_images_dir.mkdir(exist_ok=True, parents=True)
 
-    with open(dest_instances_path, "w") as f:
+    with open(dest_instances_path, "w", encoding="utf-8") as f:
         json.dump(instances, f)
 
     for image_name in kept_images_name:


### PR DESCRIPTION
As in #999 I experienced the same encoding issue on Windows (see trace-log). Since the write commands should be explicitly use the `UTF-8` encoding, I have replaced it at the occurrences in the code.

```python
Error executing job with overrides: []
Traceback (most recent call last):
  File "D:\supergradients-lab\train.py", line 137, in <module>
    main()
  File "D:\supergradients-lab\train.py", line 133, in main
    _main()
  File "C:\envs\supergradients-lab\Lib\site-packages\hydra\main.py", line 94, in decorated_main
    _run_hydra(
  File "C:\envs\supergradients-lab\Lib\site-packages\hydra\_internal\utils.py", line 394, in _run_hydra
    _run_app(
  File "C:\envs\supergradients-lab\Lib\site-packages\hydra\_internal\utils.py", line 457, in _run_app
    run_and_report(
  File "C:\envs\supergradients-lab\Lib\site-packages\hydra\_internal\utils.py", line 223, in run_and_report
    raise ex
  File "C:\envs\supergradients-lab\Lib\site-packages\hydra\_internal\utils.py", line 220, in run_and_report
    return func()
           ^^^^^^
  File "C:\envs\supergradients-lab\Lib\site-packages\hydra\_internal\utils.py", line 458, in <lambda>
    lambda: hydra.run(
            ^^^^^^^^^^
  File "C:\envs\supergradients-lab\Lib\site-packages\hydra\_internal\hydra.py", line 132, in run
    _ = ret.return_value
        ^^^^^^^^^^^^^^^^
  File "C:\envs\supergradients-lab\Lib\site-packages\hydra\core\utils.py", line 260, in return_value
    raise self._return_value
  File "C:\envs\supergradients-lab\Lib\site-packages\hydra\core\utils.py", line 186, in run_job
    ret.return_value = task_function(task_cfg)
                       ^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\supergradients-lab\train.py", line 68, in _main
    results = trainer.train(
              ^^^^^^^^^^^^^^
  File "D:\supergradients-lab\super-gradients\src\super_gradients\training\sg_trainer\sg_trainer.py", line 1253, in train
    self._initialize_sg_logger_objects(additional_configs_to_log)
  File "D:\supergradients-lab\super-gradients\src\super_gradients\training\sg_trainer\sg_trainer.py", line 2022, in _initialize_sg_logger_objects
    self.sg_logger = sg_logger_cls(**sg_logger_params)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\supergradients-lab\super-gradients\src\super_gradients\common\sg_loggers\base_sg_logger.py", line 99, in __init__
    self._init_log_file()
  File "D:\supergradients-lab\super-gradients\src\super_gradients\common\environment\ddp_utils.py", line 68, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "D:\supergradients-lab\super-gradients\src\super_gradients\common\sg_loggers\base_sg_logger.py", line 154, in _init_log_file
    AutoLoggerConfig.setup_logging(filename=self.logs_path, copy_already_logged_messages=True)
  File "D:\supergradients-lab\super-gradients\src\super_gradients\common\auto_logging\auto_logger.py", line 126, in setup_logging
    self._setup_logging(filename, copy_already_logged_messages, filemode, log_level)
  File "D:\supergradients-lab\super-gradients\src\super_gradients\common\auto_logging\auto_logger.py", line 56, in _setup_logging
    dst.write(src.read())
  File "C:\envs\supergradients-lab\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\u2713' in position 127114: character maps to <undefined>
```