### PR TITLE
fix: https://github.com/Deci-AI/super-gradients/issues/2047

### DIFF
--- a/src/super_gradients/training/utils/predict/prediction_results.py
+++ b/src/super_gradients/training/utils/predict/prediction_results.py
@@ -554,6 +554,9 @@ class ImagesDetectionPrediction(ImagesPredictions):
                 box_thickness=box_thickness,
                 show_confidence=show_confidence,
                 color_mapping=color_mapping,
+                target_bboxes=target_bbox,
+                target_bboxes_format=target_bboxes_format,
+                target_class_ids=target_class_id,
                 class_names=class_names,
             )
 


### PR DESCRIPTION
Save target map for ImagesDetectionPrediction. Before that, you can give target boxes, however it is not drown in the result images.